### PR TITLE
Structured display modes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -245,10 +245,7 @@ impl App {
             }
 
             ComboBox::new("mode chooser", "")
-                .selected_text(format!(
-                    "Display mode: {:?}",
-                    self.current_display_mode_name
-                ))
+                .selected_text(format!("Display mode: {}", self.current_display_mode_name))
                 .show_ui(ui, |ui| {
                     for mode in &self.display_modes {
                         ui.selectable_value(

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,8 +18,11 @@ use types::{
 };
 
 mod modes;
+mod structured_modes;
 mod task_timer;
 mod types;
+
+use modes::{get_all_modes, DisplayMode};
 
 fn main() -> eframe::Result {
     let options = eframe::NativeOptions {
@@ -95,7 +98,9 @@ struct App {
     timeline_bar2_time: TimePoint,
     clicked_span: Option<Rc<Span>>,
     include_children_events: bool,
-    display_mode: DisplayMode,
+    display_modes: Vec<DisplayMode>,
+    applied_display_mode_name: String,
+    current_display_mode_name: String,
     search: Search,
 }
 
@@ -110,27 +115,15 @@ struct Layout {
     middle_bar_height: f32,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-enum DisplayMode {
-    Everything,
-    Doomslug,
-    Chain,
-    ChainShard0,
-}
-
-impl DisplayMode {
-    pub fn all_modes() -> &'static [DisplayMode] {
-        &[
-            DisplayMode::Everything,
-            DisplayMode::Doomslug,
-            DisplayMode::Chain,
-            DisplayMode::ChainShard0,
-        ]
-    }
-}
-
 impl Default for App {
     fn default() -> Self {
+        let display_modes = get_all_modes();
+        let current_display_mode_name = display_modes
+            .first()
+            .expect("There should be at least one display mode")
+            .name
+            .clone();
+
         let mut res = Self {
             layout: Layout {
                 top_bar_height: 30.0,
@@ -156,7 +149,9 @@ impl Default for App {
             timeline_bar2_time: 0.0,
             clicked_span: None,
             include_children_events: true,
-            display_mode: DisplayMode::Everything,
+            display_modes,
+            applied_display_mode_name: current_display_mode_name.clone(),
+            current_display_mode_name,
             search: Search::default(),
         };
         res.timeline.init(1.0, 3.0);
@@ -249,24 +244,25 @@ impl App {
                 }
             }
 
-            let display_mode_before = self.display_mode;
             ComboBox::new("mode chooser", "")
-                .selected_text(format!("Display mode: {:?}", self.display_mode))
+                .selected_text(format!(
+                    "Display mode: {:?}",
+                    self.current_display_mode_name
+                ))
                 .show_ui(ui, |ui| {
-                    for mode in DisplayMode::all_modes() {
-                        ui.selectable_value(&mut self.display_mode, *mode, format!("{:?}", mode));
+                    for mode in &self.display_modes {
+                        ui.selectable_value(
+                            &mut self.current_display_mode_name,
+                            mode.name.clone(),
+                            format!("{:?}", mode.name),
+                        );
                     }
                 });
-            if display_mode_before != self.display_mode {
-                let res = match self.display_mode {
-                    DisplayMode::Everything => self.apply_mode(modes::everything_mode),
-                    DisplayMode::Doomslug => self.apply_mode(modes::doomslug_mode),
-                    DisplayMode::Chain => self.apply_mode(modes::chain_mode),
-                    DisplayMode::ChainShard0 => self.apply_mode(modes::chain_shard0_mode),
-                };
-                if let Err(e) = res {
-                    println!("Error applying mode: {}", e);
-                    self.display_mode = DisplayMode::Everything;
+            if self.current_display_mode_name != self.applied_display_mode_name {
+                if let Err(e) = self.apply_current_mode() {
+                    println!("Failed to apply display mode: {}", e);
+                    // Go back to the previous mode
+                    self.current_display_mode_name = self.applied_display_mode_name.clone();
                 }
             }
         });
@@ -279,7 +275,7 @@ impl App {
 
         self.raw_data = parse_trace_file(&file_bytes)?;
 
-        self.apply_mode(modes::everything_mode)?;
+        self.apply_current_mode()?;
 
         let (min_time, max_time) = get_min_max_time(&self.spans_to_display).unwrap();
         self.timeline.init(min_time, max_time);
@@ -288,13 +284,16 @@ impl App {
         Ok(())
     }
 
-    fn apply_mode(
-        &mut self,
-        mode_fn: impl Fn(&[ExportTraceServiceRequest]) -> Result<Vec<Rc<Span>>>,
-    ) -> Result<()> {
-        self.spans_to_display = mode_fn(&self.raw_data)?;
+    fn apply_current_mode(&mut self) -> Result<()> {
+        let mode = self
+            .display_modes
+            .iter()
+            .find(|m| m.name == self.current_display_mode_name)
+            .expect("Display mode not found");
+
+        self.spans_to_display = (*mode.transformation)(&self.raw_data)?;
         set_min_max_time(&self.spans_to_display);
-        //let (min_time, max_time) = get_min_max_time(&self.spans_to_display);
+
         Ok(())
     }
 

--- a/src/structured_modes.rs
+++ b/src/structured_modes.rs
@@ -1,0 +1,214 @@
+//! This module contains the definitions for structured display modes.
+//! "Structured" means that the mode is declared using a list of standardized rules, without having to write custom code.
+//! Each mode has a list of rules, each rule has a selector and a decision. The selector decides
+//! whether a rule matches a particular span, and if it does then the decision specifies how to
+//! display the span in this mode.
+
+use crate::types::{value_to_text, DisplayLength, Span};
+
+#[derive(Debug, Clone)]
+pub struct StructuredMode {
+    pub name: String,
+    /// A list of rules that define how to display spans.
+    /// For each span, the first rule that matches the span will be used to determine how to display it.
+    /// If no rule matches, the span will not be visible.
+    pub span_rules: Vec<SpanRule>,
+    /// Defines which nodes will be displayed.
+    /// If a node doesn't match any condition on this list, its spans will not be visible.
+    pub show_nodes: Vec<MatchCondition>,
+}
+
+/// A rule that defines how to display a span that matches the selector.
+#[derive(Debug, Clone)]
+pub struct SpanRule {
+    #[allow(unused)]
+    name: String,
+    /// A span that matches this selector
+    selector: SpanSelector,
+    /// Will be displayed like this
+    decision: SpanDecision,
+}
+
+/// A selector used to determine whether a span matches a rule.
+#[derive(Debug, Clone)]
+pub struct SpanSelector {
+    /// Span's name must match this condition
+    name_condition: MatchCondition,
+    /// Span's attributes must match these conditions.
+    /// If the attribute is not present, the span doesn't match the selector.
+    attribute_conditions: Vec<(String, MatchCondition)>,
+}
+
+/// Defines how to display a span that matches some rule.
+#[derive(Debug, Clone)]
+pub struct SpanDecision {
+    /// Whether the span should be visible or not.
+    pub visible: bool,
+    /// Should the span's length be defined by time or length of the name text?
+    pub display_length: DisplayLength,
+    /// If a replacement name is provided, the span's name will be replaced with this name.
+    pub replace_name: Option<String>,
+    /// Add height (e.g H=123) to the span's name, the height is read from the attributes.
+    pub add_height_to_name: bool,
+    /// Add shard id (e.g s=123) to the span's name, the shard id is read from the attributes.
+    pub add_shard_id_to_name: bool,
+}
+
+#[allow(unused)]
+#[derive(Debug, Clone)]
+pub enum MatchCondition {
+    /// Always matches
+    Any,
+    /// Never matches
+    None,
+    /// Matches if the value is equal to the given string
+    EqualTo(String),
+    /// Matches if the value is not equal to the given string
+    NotEqualTo(String),
+    /// Matches if the value contains the given substring
+    Contains(String),
+}
+
+impl MatchCondition {
+    pub fn matches(&self, value: &str) -> bool {
+        match self {
+            MatchCondition::Any => true,
+            MatchCondition::None => false,
+            MatchCondition::EqualTo(expected) => value == expected,
+            MatchCondition::NotEqualTo(expected) => value != expected,
+            MatchCondition::Contains(substring) => value.contains(substring),
+        }
+    }
+}
+
+impl StructuredMode {
+    pub fn get_decision_for_span(&self, span: &Span) -> SpanDecision {
+        let hide_decision = SpanDecision {
+            visible: false,
+            display_length: DisplayLength::Time,
+            replace_name: None,
+            add_height_to_name: false,
+            add_shard_id_to_name: false,
+        };
+
+        let mut node_matched = false;
+        for node_condition in &self.show_nodes {
+            if node_condition.matches(&span.node.name) {
+                node_matched = true;
+                break;
+            }
+        }
+        if !node_matched {
+            return hide_decision;
+        }
+
+        'rule_loop: for rule in &self.span_rules {
+            if !rule.selector.name_condition.matches(&span.name) {
+                continue;
+            }
+
+            for (attr_name, attr_condition) in &rule.selector.attribute_conditions {
+                if let Some(attr_value) = span.attributes.get(attr_name) {
+                    if !attr_condition.matches(&value_to_text(attr_value)) {
+                        continue 'rule_loop;
+                    }
+                } else {
+                    continue 'rule_loop;
+                }
+            }
+
+            return rule.decision.clone();
+        }
+
+        hide_decision
+    }
+}
+
+/// Chain mode
+pub fn chain_structured_mode() -> StructuredMode {
+    StructuredMode {
+        name: "Chain".to_string(),
+        span_rules: vec![
+            show_span("validate_chunk_state_witness"),
+            show_span("apply_new_chunk"),
+            show_span("preprocess_optimistic_block"),
+            show_span("process_optimistic_block"),
+            show_span("postprocess_ready_block"),
+            show_span("postprocess_optimistic_block"),
+            show_span("preprocess_block"),
+            show_span("apply_new_chunk"),
+            show_span("apply_old_chunk"),
+            show_span("produce_chunk_internal"),
+            show_span("produce_block_on"),
+            show_span("receive_optimistic_block"),
+            show_span("validate_chunk_state_witness"),
+            show_span("send_chunk_state_witness"),
+            show_span("produce_optimistic_block_on_head"),
+            show_span("validate_chunk_endorsement"),
+            show_span("on_approval_message"),
+        ],
+        show_nodes: vec![MatchCondition::Any],
+    }
+}
+
+/// Everything mode
+pub fn everything_structured_mode() -> StructuredMode {
+    StructuredMode {
+        name: "Everything".to_string(),
+        span_rules: vec![
+            // Show "verify_chunk_endorsement" as "VCE", helps with performance.
+            SpanRule {
+                name: "Shorter verify_chunk_endorsement".to_string(),
+                selector: SpanSelector {
+                    name_condition: MatchCondition::EqualTo("verify_chunk_endorsement".to_string()),
+                    attribute_conditions: vec![],
+                },
+                decision: SpanDecision {
+                    visible: true,
+                    display_length: DisplayLength::Time,
+                    replace_name: Some("VCE".to_string()),
+                    add_height_to_name: true,
+                    add_shard_id_to_name: true,
+                },
+            },
+            // All spans should be visible, their length should be based on time.
+            SpanRule {
+                name: "Show all".to_string(),
+                selector: SpanSelector {
+                    name_condition: MatchCondition::Any,
+                    attribute_conditions: vec![],
+                },
+                decision: SpanDecision {
+                    visible: true,
+                    display_length: DisplayLength::Time,
+                    replace_name: None,
+                    add_height_to_name: true,
+                    add_shard_id_to_name: true,
+                },
+            },
+        ],
+        show_nodes: vec![MatchCondition::Any],
+    }
+}
+
+fn show_span(name: &str) -> SpanRule {
+    SpanRule {
+        name: format!("Show {}", name),
+        selector: SpanSelector {
+            name_condition: MatchCondition::EqualTo(name.to_string()),
+            attribute_conditions: vec![],
+        },
+        decision: SpanDecision {
+            visible: true,
+            display_length: DisplayLength::Text,
+            replace_name: None,
+            add_height_to_name: true,
+            add_shard_id_to_name: true,
+        },
+    }
+}
+
+/// List of all modes
+pub fn get_all_structured_modes() -> Vec<StructuredMode> {
+    vec![chain_structured_mode(), everything_structured_mode()]
+}


### PR DESCRIPTION
Add structured display modes.

"Structured" means that the mode is defined by a set of standardized rules. The rules are written in a declarative manner, without having to write any code or knowing how internals of Traviz work.

Having standardized way of specifying display modes also allows to configure them from the UI, which will be added in the future.