### PR TITLE
feat: add analyze feature for span and span dependencies

### DIFF
--- a/src/analyze_dependency.rs
+++ b/src/analyze_dependency.rs
@@ -2,7 +2,8 @@ use crate::analyze_utils::{self, Statistics};
 use crate::types::Span;
 use crate::types::MILLISECONDS_PER_SECOND;
 use eframe::egui::{
-    self, Button, Color32, ComboBox, Grid, Key, Layout, Modal, ScrollArea, TextEdit, Vec2,
+    self, Align, Button, Color32, ComboBox, Grid, Id, Key, Layout, Modal, RichText, ScrollArea,
+    TextEdit, Vec2,
 };
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
@@ -631,50 +632,50 @@ impl AnalyzeDependencyModal {
                             // Create header cells with consistent width and borders
                             ui.scope(|ui| {
                                 ui.set_min_width(col_widths[0]);
-                                ui.strong(egui::RichText::new("Node").monospace());
+                                ui.strong(RichText::new("Node").monospace());
                             });
                             ui.scope(|ui| {
                                 ui.set_min_width(col_widths[1]);
                                 ui.with_layout(
-                                    egui::Layout::right_to_left(egui::Align::Center),
+                                    Layout::right_to_left(Align::Center),
                                     |ui| {
-                                        ui.strong(egui::RichText::new("Count").monospace());
+                                        ui.strong(RichText::new("Count").monospace());
                                     },
                                 );
                             });
                             ui.scope(|ui| {
                                 ui.set_min_width(col_widths[2]);
                                 ui.with_layout(
-                                    egui::Layout::right_to_left(egui::Align::Center),
+                                    Layout::right_to_left(Align::Center),
                                     |ui| {
-                                        ui.strong(egui::RichText::new("Min (ms)").monospace());
+                                        ui.strong(RichText::new("Min (ms)").monospace());
                                     },
                                 );
                             });
                             ui.scope(|ui| {
                                 ui.set_min_width(col_widths[3]);
                                 ui.with_layout(
-                                    egui::Layout::right_to_left(egui::Align::Center),
+                                    Layout::right_to_left(Align::Center),
                                     |ui| {
-                                        ui.strong(egui::RichText::new("Max (ms)").monospace());
+                                        ui.strong(RichText::new("Max (ms)").monospace());
                                     },
                                 );
                             });
                             ui.scope(|ui| {
                                 ui.set_min_width(col_widths[4]);
                                 ui.with_layout(
-                                    egui::Layout::right_to_left(egui::Align::Center),
+                                    Layout::right_to_left(Align::Center),
                                     |ui| {
-                                        ui.strong(egui::RichText::new("Mean (ms)").monospace());
+                                        ui.strong(RichText::new("Mean (ms)").monospace());
                                     },
                                 );
                             });
                             ui.scope(|ui| {
                                 ui.set_min_width(col_widths[5]);
                                 ui.with_layout(
-                                    egui::Layout::right_to_left(egui::Align::Center),
+                                    Layout::right_to_left(Align::Center),
                                     |ui| {
-                                        ui.strong(egui::RichText::new("Median (ms)").monospace());
+                                        ui.strong(RichText::new("Median (ms)").monospace());
                                     },
                                 );
                             });
@@ -686,8 +687,8 @@ impl AnalyzeDependencyModal {
 
                     // Store the grid width and column percentages for the data grid
                     ui.memory_mut(|mem| {
-                        mem.data.insert_temp(egui::Id::new("dependency_grid_width"), grid_width);
-                        mem.data.insert_temp(egui::Id::new("dependency_col_percentages"), col_percentages);
+                        mem.data.insert_temp(Id::new("dependency_grid_width"), grid_width);
+                        mem.data.insert_temp(Id::new("dependency_col_percentages"), col_percentages);
                     });
                 }
 
@@ -706,9 +707,9 @@ impl AnalyzeDependencyModal {
                         if let Some(result) = &self.analysis_result {
                             // Retrieve the stored grid width and column percentages
                             let (grid_width, col_percentages) = ui.memory(|mem| {
-                                let width = mem.data.get_temp::<f32>(egui::Id::new("dependency_grid_width"))
+                                let width = mem.data.get_temp::<f32>(Id::new("dependency_grid_width"))
                                     .unwrap_or_else(|| ui.available_width());
-                                let percentages = mem.data.get_temp::<[f32; 6]>(egui::Id::new("dependency_col_percentages"))
+                                let percentages = mem.data.get_temp::<[f32; 6]>(Id::new("dependency_col_percentages"))
                                     .unwrap_or([0.25, 0.1, 0.15, 0.2, 0.15, 0.15]);
                                 (width, percentages)
                             });
@@ -745,7 +746,7 @@ impl AnalyzeDependencyModal {
                                                 ui.set_min_width(col_widths[0]);
                                                 ui.horizontal(|ui| {
                                                     ui.label(
-                                                        egui::RichText::new(&node_name).monospace(),
+                                                        RichText::new(&node_name).monospace(),
                                                     );
                                                     ui.add_space(5.0); // Padding
                                                     let focus_response = ui.button("🔍");
@@ -762,10 +763,10 @@ impl AnalyzeDependencyModal {
                                                 ui.scope(|ui| {
                                                     ui.set_min_width(col_widths[1]);
                                                     ui.with_layout(
-                                                        egui::Layout::right_to_left(egui::Align::Center),
+                                                        Layout::right_to_left(Align::Center),
                                                         |ui| {
                                                             ui.label(
-                                                                egui::RichText::new(format!("{}", stats.count))
+                                                                RichText::new(format!("{}", stats.count))
                                                                     .monospace(),
                                                             );
                                                         },
@@ -775,10 +776,10 @@ impl AnalyzeDependencyModal {
                                                 ui.scope(|ui| {
                                                     ui.set_min_width(col_widths[2]);
                                                     ui.with_layout(
-                                                        egui::Layout::right_to_left(egui::Align::Center),
+                                                        Layout::right_to_left(Align::Center),
                                                         |ui| {
                                                             ui.label(
-                                                                egui::RichText::new(format!("{:.3}", stats.min * MILLISECONDS_PER_SECOND))
+                                                                RichText::new(format!("{:.3}", stats.min * MILLISECONDS_PER_SECOND))
                                                                     .monospace()
                                                                     .color(Color32::from_rgb(50, 150, 200)),
                                                             );
@@ -789,10 +790,10 @@ impl AnalyzeDependencyModal {
                                                 ui.scope(|ui| {
                                                     ui.set_min_width(col_widths[3]);
                                                     ui.with_layout(
-                                                        egui::Layout::right_to_left(egui::Align::Center),
+                                                        Layout::right_to_left(Align::Center),
                                                         |ui| {
                                                             ui.label(
-                                                                egui::RichText::new(format!("{:.3}", stats.max * MILLISECONDS_PER_SECOND))
+                                                                RichText::new(format!("{:.3}", stats.max * MILLISECONDS_PER_SECOND))
                                                                     .monospace()
                                                                     .color(Color32::from_rgb(50, 150, 200)),
                                                             );
@@ -803,10 +804,10 @@ impl AnalyzeDependencyModal {
                                                 ui.scope(|ui| {
                                                     ui.set_min_width(col_widths[4]);
                                                     ui.with_layout(
-                                                        egui::Layout::right_to_left(egui::Align::Center),
+                                                        Layout::right_to_left(Align::Center),
                                                         |ui| {
                                                             ui.label(
-                                                                egui::RichText::new(format!("{:.3}", stats.mean() * MILLISECONDS_PER_SECOND))
+                                                                RichText::new(format!("{:.3}", stats.mean() * MILLISECONDS_PER_SECOND))
                                                                     .monospace(),
                                                             );
                                                         },
@@ -816,10 +817,10 @@ impl AnalyzeDependencyModal {
                                                 ui.scope(|ui| {
                                                     ui.set_min_width(col_widths[5]);
                                                     ui.with_layout(
-                                                        egui::Layout::right_to_left(egui::Align::Center),
+                                                        Layout::right_to_left(Align::Center),
                                                         |ui| {
                                                             ui.label(
-                                                                egui::RichText::new(format!("{:.3}", stats.median() * MILLISECONDS_PER_SECOND)) // Corrected: median is also in ms
+                                                                RichText::new(format!("{:.3}", stats.median() * MILLISECONDS_PER_SECOND)) // Corrected: median is also in ms
                                                                     .monospace(),
                                                             );
                                                         },
@@ -831,10 +832,10 @@ impl AnalyzeDependencyModal {
                                                     ui.scope(|ui| {
                                                         ui.set_min_width(*col_width);
                                                         ui.with_layout(
-                                                            egui::Layout::right_to_left(egui::Align::Center),
+                                                            Layout::right_to_left(Align::Center),
                                                             |ui| {
                                                                 ui.label(
-                                                                    egui::RichText::new("-").monospace(),
+                                                                    RichText::new("-").monospace(),
                                                                 );
                                                             },
                                                         );
@@ -850,7 +851,7 @@ impl AnalyzeDependencyModal {
                                         ui.scope(|ui| {
                                             ui.set_min_width(col_widths[0]);
                                             ui.label(
-                                                egui::RichText::new("No matching dependencies found").monospace(),
+                                                RichText::new("No matching dependencies found").monospace(),
                                             );
                                         });
                                         for _ in 0..5 {

--- a/src/analyze_dependency.rs
+++ b/src/analyze_dependency.rs
@@ -1,5 +1,6 @@
 use crate::analyze_utils::{self, Statistics};
 use crate::types::Span;
+use crate::types::MILLISECONDS_PER_SECOND;
 use eframe::egui::{
     self, Button, Color32, ComboBox, Grid, Key, Layout, Modal, ScrollArea, TextEdit, Vec2,
 };
@@ -777,7 +778,7 @@ impl AnalyzeDependencyModal {
                                                         egui::Layout::right_to_left(egui::Align::Center),
                                                         |ui| {
                                                             ui.label(
-                                                                egui::RichText::new(format!("{:.3}", stats.min * 1000.0))
+                                                                egui::RichText::new(format!("{:.3}", stats.min * MILLISECONDS_PER_SECOND))
                                                                     .monospace()
                                                                     .color(Color32::from_rgb(50, 150, 200)),
                                                             );
@@ -791,7 +792,7 @@ impl AnalyzeDependencyModal {
                                                         egui::Layout::right_to_left(egui::Align::Center),
                                                         |ui| {
                                                             ui.label(
-                                                                egui::RichText::new(format!("{:.3}", stats.max * 1000.0))
+                                                                egui::RichText::new(format!("{:.3}", stats.max * MILLISECONDS_PER_SECOND))
                                                                     .monospace()
                                                                     .color(Color32::from_rgb(50, 150, 200)),
                                                             );
@@ -805,7 +806,7 @@ impl AnalyzeDependencyModal {
                                                         egui::Layout::right_to_left(egui::Align::Center),
                                                         |ui| {
                                                             ui.label(
-                                                                egui::RichText::new(format!("{:.3}", stats.mean() * 1000.0))
+                                                                egui::RichText::new(format!("{:.3}", stats.mean() * MILLISECONDS_PER_SECOND))
                                                                     .monospace(),
                                                             );
                                                         },
@@ -818,7 +819,7 @@ impl AnalyzeDependencyModal {
                                                         egui::Layout::right_to_left(egui::Align::Center),
                                                         |ui| {
                                                             ui.label(
-                                                                egui::RichText::new(format!("{:.3}", stats.median() * 1000.0)) // Corrected: median is also in ms
+                                                                egui::RichText::new(format!("{:.3}", stats.median() * MILLISECONDS_PER_SECOND)) // Corrected: median is also in ms
                                                                     .monospace(),
                                                             );
                                                         },

--- a/src/analyze_dependency.rs
+++ b/src/analyze_dependency.rs
@@ -55,9 +55,9 @@ pub struct AnalyzeDependencyModal {
     /// Whether the modal window is currently visible.
     pub show: bool,
     /// Text entered by the user in the source span name search box.
-    pub source_search_text: String,
+    source_search_text: String,
     /// Text entered by the user in the target span name search box.
-    pub target_search_text: String,
+    target_search_text: String,
     /// The name of the source span currently selected by the user.
     source_span_name: Option<String>,
     /// The name of the target span currently selected by the user.
@@ -112,6 +112,14 @@ impl AnalyzeDependencyModal {
         self.target_search_text = String::new();
         self.update_span_list(spans_for_analysis);
         self.spans_processed = true;
+    }
+
+    pub fn reset_processed_flag(&mut self) {
+        self.spans_processed = false;
+    }
+
+    pub fn clear_focus(&mut self) {
+        self.focus_node = None;
     }
 
     pub fn update_span_list(&mut self, spans: &[Rc<Span>]) {

--- a/src/analyze_dependency.rs
+++ b/src/analyze_dependency.rs
@@ -606,8 +606,8 @@ impl AnalyzeDependencyModal {
                 // These will be properly set if analysis_result is Some,
                 // and the ScrollArea that uses them is only shown in that case.
                 let mut grid_width = 0.0;
-                // Define percentage-based column widths that sum exactly to 100%
-                let col_percentages = [0.25, 0.1, 0.15, 0.2, 0.15, 0.15]; // Node, Count, Min, Max, Mean, Median
+                // Define percentage-based column widths
+                let col_percentages = [0.25, 0.14, 0.14, 0.14, 0.14, 0.14]; // Node, Count, Min, Max, Mean, Median
 
                 if let Some(result) = &self.analysis_result {
                     ui.horizontal(|ui| {
@@ -689,7 +689,7 @@ impl AnalyzeDependencyModal {
                                                     ui_horiz.label(
                                                         RichText::new(&node_name).monospace(),
                                                     );
-                                                    ui_horiz.add_space(5.0); // Padding
+                                                    ui_horiz.add_space(5.0);
                                                     let focus_response = ui_horiz.button("🔍");
                                                     if focus_response.clicked() {
                                                         self.focus_node = Some(node_name.clone());

--- a/src/analyze_dependency.rs
+++ b/src/analyze_dependency.rs
@@ -1,0 +1,911 @@
+use crate::analyze_utils::{self, Statistics};
+use crate::types::Span;
+use eframe::egui::{
+    self, Button, Color32, ComboBox, Grid, Key, Layout, Modal, ScrollArea, TextEdit, Vec2,
+};
+use std::collections::{HashMap, HashSet};
+use std::rc::Rc;
+use std::time::Instant;
+
+// Structure to represent a dependency link between spans
+pub struct DependencyLink {
+    pub source_spans: Vec<Rc<Span>>,
+    pub target_span: Rc<Span>,
+}
+
+// Analysis result for a specific node
+pub struct NodeDependencyResult {
+    pub statistics: Statistics,
+    pub links: Vec<DependencyLink>,
+}
+
+// Overall analysis result
+pub struct DependencyAnalysisResult {
+    pub source_span_name: String,
+    pub target_span_name: String,
+    pub threshold: usize,
+    pub metadata_field: String,
+    pub source_scope: String,
+    pub per_node_results: HashMap<String, NodeDependencyResult>,
+    pub analysis_duration_ms: u128,
+}
+
+#[derive(Default)]
+pub struct AnalyzeDependencyModal {
+    pub show: bool,
+    pub source_search_text: String,
+    pub target_search_text: String,
+    pub source_span_name: Option<String>,
+    pub target_span_name: Option<String>,
+    pub threshold: usize,
+    pub threshold_edit_str: String,
+    pub metadata_field: String,
+    pub source_scope: String,
+    pub unique_span_names: Vec<String>,
+    pub spans_processed: bool,
+    pub analysis_result: Option<DependencyAnalysisResult>,
+    pub error_message: Option<String>,
+    stored_spans: Vec<Rc<Span>>,
+    pub focus_node: Option<String>,
+}
+
+impl AnalyzeDependencyModal {
+    pub fn new() -> Self {
+        let initial_threshold = 1;
+        Self {
+            show: false,
+            source_search_text: String::new(),
+            target_search_text: String::new(),
+            source_span_name: None,
+            target_span_name: None,
+            threshold: initial_threshold,
+            threshold_edit_str: initial_threshold.to_string(),
+            metadata_field: String::new(),
+            source_scope: "self".to_string(),
+            unique_span_names: Vec::new(),
+            spans_processed: false,
+            analysis_result: None,
+            error_message: None,
+            stored_spans: Vec::new(),
+            focus_node: None,
+        }
+    }
+
+    // Update span list and store spans internally
+    pub fn update_span_list(&mut self, spans: &[Rc<Span>]) {
+        // Store all spans including children
+        self.stored_spans.clear();
+
+        // Collect all spans including children
+        for span in spans {
+            analyze_utils::collect_all_spans(span, &mut self.stored_spans);
+        }
+
+        println!(
+            "Stored {} total spans in the dependency analyze modal",
+            self.stored_spans.len()
+        );
+
+        // Create a set of unique span names
+        let mut unique_span_names: HashSet<String> = HashSet::new();
+
+        for span in &self.stored_spans {
+            unique_span_names.insert(span.name.clone());
+        }
+
+        // Convert to sorted vector
+        self.unique_span_names = unique_span_names.into_iter().collect();
+        self.unique_span_names.sort_by_key(|a| a.to_lowercase());
+    }
+
+    // Analyze dependencies between spans
+    fn analyze_dependencies(&mut self) {
+        // Validate source and target span names
+        let source_name = match &self.source_span_name {
+            Some(name) => name.clone(),
+            None => {
+                self.error_message = Some("Source span not selected".to_string());
+                return;
+            }
+        };
+
+        let target_name = match &self.target_span_name {
+            Some(name) => name.clone(),
+            None => {
+                self.error_message = Some("Target span not selected".to_string());
+                return;
+            }
+        };
+
+        // Validate that source and target spans are different
+        if source_name == target_name {
+            self.error_message = Some("Source and target spans must be different".to_string());
+            return;
+        }
+
+        // Start timing the analysis
+        let analysis_start = Instant::now();
+
+        // Collect all source and target spans
+        let mut source_spans = Vec::new();
+        let mut target_spans = Vec::new();
+
+        analyze_utils::collect_matching_spans(&self.stored_spans, &source_name, &mut source_spans);
+        analyze_utils::collect_matching_spans(&self.stored_spans, &target_name, &mut target_spans);
+
+        if source_spans.is_empty() {
+            self.error_message = Some(format!("No spans found with name '{}'", source_name));
+            return;
+        }
+
+        if target_spans.is_empty() {
+            self.error_message = Some(format!("No spans found with name '{}'", target_name));
+            return;
+        }
+
+        // Sort spans by start time
+        source_spans.sort_by(|a, b| {
+            a.start_time
+                .partial_cmp(&b.start_time)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        target_spans.sort_by(|a, b| {
+            a.start_time
+                .partial_cmp(&b.start_time)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+
+        // Group spans by node
+        let mut source_spans_by_node: HashMap<String, Vec<Rc<Span>>> = HashMap::new();
+        let mut target_spans_by_node: HashMap<String, Vec<Rc<Span>>> = HashMap::new();
+
+        for span in source_spans {
+            source_spans_by_node
+                .entry(span.node.name.clone())
+                .or_default()
+                .push(span);
+        }
+
+        for span in target_spans {
+            target_spans_by_node
+                .entry(span.node.name.clone())
+                .or_default()
+                .push(span);
+        }
+
+        // Per-node dependency analysis
+        let mut per_node_results = HashMap::new();
+        let node_names = if self.source_scope == "self" {
+            // Only analyze nodes that have both source and target spans
+            source_spans_by_node
+                .keys()
+                .filter(|node_name| target_spans_by_node.contains_key(*node_name))
+                .cloned()
+                .collect::<Vec<String>>()
+        } else {
+            // "all nodes"
+            // Use source nodes and target nodes
+            let mut all_nodes = HashSet::new();
+            all_nodes.extend(source_spans_by_node.keys().cloned());
+            all_nodes.extend(target_spans_by_node.keys().cloned());
+            all_nodes.into_iter().collect()
+        };
+
+        // This set is for 'self' mode: if a source span is a potential candidate for any target, it's marked used globally.
+        let mut global_used_source_span_ids_for_self_mode: HashSet<Vec<u8>> = HashSet::new();
+
+        for node_name in node_names {
+            let current_source_node_spans = if self.source_scope == "self" {
+                // Only use spans from this node
+                source_spans_by_node
+                    .get(&node_name)
+                    .cloned()
+                    .unwrap_or_default()
+            } else {
+                // Use spans from all nodes, sorted by time
+                let mut all_s_spans: Vec<Rc<Span>> =
+                    source_spans_by_node.values().flatten().cloned().collect();
+                all_s_spans.sort_by(|a, b| {
+                    a.start_time
+                        .partial_cmp(&b.start_time)
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                });
+                all_s_spans
+            };
+
+            // Skip if no source spans for this node/scope
+            if current_source_node_spans.is_empty() {
+                continue;
+            }
+
+            // Get target spans (always from the current node being processed for targets)
+            let current_target_node_spans = target_spans_by_node
+                .get(&node_name)
+                .cloned()
+                .unwrap_or_default();
+
+            // Skip if no target spans for this node
+            if current_target_node_spans.is_empty() {
+                continue;
+            }
+
+            // Find valid links
+            let mut node_links = Vec::new();
+            let mut statistics = Statistics::new();
+            let mut used_target_spans: HashSet<Vec<u8>> = HashSet::new();
+            // For "all nodes" mode: tracks source spans that have successfully linked to a target on *this specific target_node*. Reset for each target_node.
+            let mut source_spans_linked_on_this_target_node_in_all_nodes_mode: HashSet<Vec<u8>> =
+                HashSet::new();
+
+            for target_span in current_target_node_spans.iter() {
+                if used_target_spans.contains(&target_span.span_id) {
+                    continue; // This target has already been linked by a source group.
+                }
+
+                // Check metadata for target_span if specified
+                if !self.metadata_field.is_empty()
+                    && !target_span.attributes.contains_key(&self.metadata_field)
+                {
+                    continue; // Target itself must have the metadata field to be a candidate
+                }
+
+                let mut potential_sources_for_this_target: Vec<Rc<Span>> = Vec::new();
+                for s_span in current_source_node_spans.iter() {
+                    // Check if source span already used based on mode
+                    let mut skip_source = false;
+                    if self.source_scope == "self" {
+                        if global_used_source_span_ids_for_self_mode.contains(&s_span.span_id) {
+                            skip_source = true;
+                        }
+                    } else {
+                        // "all nodes" mode
+                        if source_spans_linked_on_this_target_node_in_all_nodes_mode
+                            .contains(&s_span.span_id)
+                        {
+                            skip_source = true;
+                        }
+                    }
+                    if skip_source {
+                        continue;
+                    }
+
+                    // Basic time validity
+                    if s_span.end_time < target_span.start_time {
+                        // Check metadata compatibility if field is specified
+                        if !self.metadata_field.is_empty() {
+                            // Source must also have the metadata field
+                            if !s_span.attributes.contains_key(&self.metadata_field) {
+                                continue;
+                            }
+                            // Values must match (target_span's field existence already checked)
+                            let source_value = &s_span.attributes[&self.metadata_field];
+                            let target_value = &target_span.attributes[&self.metadata_field];
+                            if source_value != target_value {
+                                continue;
+                            }
+                        }
+                        potential_sources_for_this_target.push(s_span.clone());
+                    }
+                }
+
+                // potential_sources_for_this_target are already sorted by start_time.
+
+                if potential_sources_for_this_target.len() >= self.threshold && self.threshold > 0 {
+                    let num_to_take = self.threshold; // Or some other logic, e.g. potential_sources_for_this_target.len() to take all
+                    let selected_source_spans_group: Vec<Rc<Span>> =
+                        potential_sources_for_this_target
+                            .iter()
+                            // .rev() // If you want the latest ones before the target
+                            .take(num_to_take)
+                            .cloned()
+                            .collect();
+
+                    if !selected_source_spans_group.is_empty() {
+                        // Should always be true if num_to_take > 0 and len >= threshold
+                        let last_source_in_group = selected_source_spans_group.last().unwrap();
+
+                        if last_source_in_group.end_time < target_span.start_time {
+                            // Final check
+                            let distance = target_span.start_time - last_source_in_group.end_time;
+
+                            statistics.add_value(distance); // Use existing statistics method
+                            node_links.push(DependencyLink {
+                                source_spans: selected_source_spans_group.clone(),
+                                target_span: target_span.clone(),
+                            });
+
+                            used_target_spans.insert(target_span.span_id.clone());
+
+                            // Mark the *actually linked* source spans as used for the appropriate scope.
+                            for linked_s_span in &selected_source_spans_group {
+                                if self.source_scope == "self" {
+                                    // In 'self' mode, linked spans are added to the global set.
+                                    // Note: potential_sources are also added below, preserving original broader consumption.
+                                    global_used_source_span_ids_for_self_mode
+                                        .insert(linked_s_span.span_id.clone());
+                                } else {
+                                    // "all nodes" mode
+                                    // In 'all nodes' mode, mark this source as used for this specific target node.
+                                    source_spans_linked_on_this_target_node_in_all_nodes_mode
+                                        .insert(linked_s_span.span_id.clone());
+                                }
+                            }
+                        } else {
+                            // This case (last source in group not ending before target) should ideally not happen
+                            // if potential_sources_for_this_target are correctly filtered.
+                            // Consider logging if it occurs.
+                        }
+                    }
+                }
+
+                // For "self" mode: preserve original behavior where *all potential* sources for this target are marked globally used.
+                // This runs after link formation attempt for the current target_span.
+                if self.source_scope == "self" {
+                    for s_potential_for_this_target in &potential_sources_for_this_target {
+                        global_used_source_span_ids_for_self_mode
+                            .insert(s_potential_for_this_target.span_id.clone());
+                    }
+                }
+            }
+
+            // Add result for this node if any links were formed
+            if !node_links.is_empty() || statistics.count > 0 {
+                // Ensure node result is added even if links are empty but stats were somehow processed (though unlikely with this logic)
+                per_node_results.insert(
+                    node_name.clone(),
+                    NodeDependencyResult {
+                        statistics,
+                        links: node_links,
+                    },
+                );
+            }
+        }
+
+        // Measure analysis duration
+        let analysis_duration = analysis_start.elapsed().as_millis();
+
+        // Store the results
+        self.analysis_result = Some(DependencyAnalysisResult {
+            source_span_name: source_name,
+            target_span_name: target_name,
+            threshold: self.threshold,
+            metadata_field: self.metadata_field.clone(),
+            source_scope: self.source_scope.clone(),
+            per_node_results,
+            analysis_duration_ms: analysis_duration,
+        });
+
+        self.error_message = None;
+    }
+
+    // Show the modal
+    pub fn show_modal(
+        &mut self,
+        ctx: &egui::Context,
+        spans: &[Rc<Span>],
+        max_width: f32,
+        max_height: f32,
+    ) {
+        if !self.show {
+            return;
+        }
+
+        // Only update the span list if we have new spans and they're not empty
+        if !self.spans_processed && !spans.is_empty() {
+            self.update_span_list(spans);
+            self.spans_processed = true;
+        }
+
+        let mut modal_closed = false;
+
+        Modal::new("analyze dependency".into()).show(ctx, |ui| {
+            ui.vertical(|ui| {
+                ui.set_max_width(max_width);
+                ui.set_max_height(max_height);
+
+                ui.heading("Analyze Dependency");
+                ui.add_space(10.0);
+
+                // Use a Grid for Source and Target span selection and lists
+                egui::Grid::new("source_target_grid")
+                    .num_columns(2)
+                    .spacing([20.0, 10.0]) // Spacing between columns and rows
+                    .striped(false)
+                    .show(ui, |ui| {
+                        // --- Row 1: Search Boxes ---
+                        // Source span search
+                        ui.vertical(|ui| {
+                            ui.set_width(max_width * 0.45); // Maintain overall width proportion
+                            analyze_utils::span_search_ui(
+                                ui,
+                                &mut self.source_search_text,
+                                "Source Span:",
+                                "Search source span",
+                                ui.available_width() // Use available width within the cell
+                            );
+                        });
+                        // Target span search
+                        ui.vertical(|ui| {
+                            ui.set_width(max_width * 0.45); // Maintain overall width proportion
+                            analyze_utils::span_search_ui(
+                                ui,
+                                &mut self.target_search_text,
+                                "Target Span:",
+                                "Search target span",
+                                ui.available_width() // Use available width within the cell
+                            );
+                        });
+                        ui.end_row();
+
+                        // --- Row 2: Span Lists ---
+                        let list_height = 150.0;
+                        // Source span list
+                        ui.vertical(|ui| {
+                            ui.set_width(max_width * 0.45);
+                            analyze_utils::span_selection_list_ui(
+                                ui,
+                                &self.unique_span_names,
+                                &self.source_search_text,
+                                &mut self.source_span_name,
+                                list_height,
+                                "source_spans_list"
+                            );
+                        });
+                        // Target span list
+                        ui.vertical(|ui| {
+                            ui.set_width(max_width * 0.45);
+                            analyze_utils::span_selection_list_ui(
+                                ui,
+                                &self.unique_span_names,
+                                &self.target_search_text,
+                                &mut self.target_span_name,
+                                list_height,
+                                "target_spans_list"
+                            );
+                        });
+                        ui.end_row();
+                    });
+
+                ui.add_space(10.0);
+                ui.separator();
+                ui.add_space(10.0);
+
+                // Configuration row
+                ui.horizontal(|ui| {
+                    // Threshold input (integer, min 1)
+                    ui.vertical(|ui| {
+                        ui.horizontal(|ui| {
+                            ui.label("Threshold:");
+                            let response = ui.add(
+                                TextEdit::singleline(&mut self.threshold_edit_str)
+                                    .desired_width(50.0)
+                                    .text_color(Color32::LIGHT_GRAY)
+                            );
+
+                            let mut commit_valid_input = false;
+                            if response.lost_focus() {
+                                commit_valid_input = true;
+                            }
+
+                            if commit_valid_input {
+                                if let Ok(value) = self.threshold_edit_str.parse::<usize>() {
+                                    self.threshold = value.max(1); // Ensure minimum of 1
+                                } // If parse fails, self.threshold remains, and string will be reset below
+                                // Always reset edit string from the (potentially updated) numeric value after commit attempt
+                                self.threshold_edit_str = self.threshold.to_string();
+                            } else if response.changed() {
+                                // User is typing. If they type something invalid, allow it in the text box for now.
+                                // It will be validated/reverted on commit (lost_focus/enter).
+                                // Optionally, we could try to parse here and give immediate feedback (e.g. red text box)
+                                // but the current approach is simpler: validate on commit.
+                            }
+
+                            if response.hovered() {
+                                response.on_hover_text("Specifies which source span to use (e.g., 2 means use every second source span)");
+                            }
+                        });
+                    });
+
+                    ui.add_space(10.0);
+
+                    // Link Metadata Matcher input
+                    ui.vertical(|ui| {
+                        ui.horizontal(|ui| {
+                            ui.label("Link Metadata Matcher:");
+                            let response = ui.add(
+                                TextEdit::singleline(&mut self.metadata_field)
+                                    .desired_width(120.0)
+                                    .hint_text("field name")
+                                    .text_color(Color32::LIGHT_GRAY)
+                            );
+
+                            if response.hovered() {
+                                response.on_hover_text(
+                                    "Optional. If provided, only spans with matching values for this metadata field can form links. \
+                                    Leave empty to ignore metadata matching."
+                                );
+                            }
+                        });
+                    });
+
+                    ui.add_space(10.0);
+
+                    // Source toggle dropdown
+                    ui.vertical(|ui| {
+                        ui.horizontal(|ui| {
+                            ui.label("Source:");
+                            let combo_box_response = ComboBox::new(ui.id().with("source_scope"), "")
+                                .selected_text(&self.source_scope)
+                                .width(80.0)
+                                .show_ui(ui, |ui| {
+                                    ui.selectable_value(&mut self.source_scope, "self".to_string(), "self");
+                                    ui.selectable_value(&mut self.source_scope, "all nodes".to_string(), "all nodes");
+                                });
+
+                            // Attach hover text to the ComboBox response itself
+                            combo_box_response.response.on_hover_text("'self' only considers sources from the same node as target. 'all nodes' considers sources from any node.");
+                        });
+                    });
+
+                    ui.add_space(20.0);
+
+                    // Analyze button (right side)
+                    ui.with_layout(Layout::right_to_left(eframe::emath::Align::Center), |ui| {
+                        let is_ready = self.source_span_name.is_some() && self.target_span_name.is_some();
+                        if ui
+                            .add_enabled(
+                                is_ready,
+                                Button::new("Analyze").min_size(Vec2::new(100.0, 30.0)),
+                            )
+                            .clicked()
+                        {
+                            self.analyze_dependencies();
+                        }
+                    });
+                });
+
+                ui.add_space(10.0);
+
+                // Display error message if any
+                if let Some(error) = &self.error_message {
+                    ui.horizontal(|ui| {
+                        ui.colored_label(Color32::from_rgb(220, 50, 50), error);
+                    });
+                }
+
+                ui.separator();
+
+                // Results area
+                ui.label("Dependency Analysis Results:");
+
+                if let Some(result) = &self.analysis_result {
+                    ui.horizontal(|ui| {
+                        ui.label(format!(
+                            "Analysis of dependency: '{}' -> '{}' (threshold: {}, metadata field: {}, source: {})",
+                            result.source_span_name,
+                            result.target_span_name,
+                            result.threshold,
+                            if result.metadata_field.is_empty() { "none" } else { &result.metadata_field },
+                            result.source_scope
+                        ));
+
+                        ui.label(format!("(Analysis took {} ms)", result.analysis_duration_ms));
+                    });
+                }
+
+                // Create the grid headers first outside the scroll area (to keep them visible)
+                if self.analysis_result.is_some() {
+                    ui.add_space(10.0);
+
+                    let available_width = ui.available_width();
+
+                    // Define percentage-based column widths that sum exactly to 100%
+                    let col_percentages = [0.25, 0.1, 0.15, 0.2, 0.15, 0.15]; // Sums to 1.0
+
+                    let grid_width = available_width;
+
+                    // Calculate pixel widths for columns based on percentages
+                    let col_widths = [
+                        (grid_width * col_percentages[0]).max(140.0), // Node
+                        (grid_width * col_percentages[1]).max(60.0),  // Count
+                        (grid_width * col_percentages[2]).max(80.0),  // Min
+                        (grid_width * col_percentages[3]).max(80.0),  // Max
+                        (grid_width * col_percentages[4]).max(80.0),  // Mean
+                        (grid_width * col_percentages[5]).max(80.0),  // Median
+                    ];
+
+                    // Header row - outside scrollable area to make it sticky
+                    Grid::new("dependency_analysis_header_grid")
+                        .num_columns(6)
+                        .spacing([10.0, 6.0])
+                        .striped(true)
+                        .min_col_width(0.0) // Let the explicit width settings handle sizing
+                        .show(ui, |ui| {
+                            // Create header cells with consistent width and borders
+                            ui.scope(|ui| {
+                                ui.set_min_width(col_widths[0]);
+                                ui.strong(egui::RichText::new("Node").monospace());
+                            });
+                            ui.scope(|ui| {
+                                ui.set_min_width(col_widths[1]);
+                                ui.with_layout(
+                                    egui::Layout::right_to_left(egui::Align::Center),
+                                    |ui| {
+                                        ui.strong(egui::RichText::new("Count").monospace());
+                                    },
+                                );
+                            });
+                            ui.scope(|ui| {
+                                ui.set_min_width(col_widths[2]);
+                                ui.with_layout(
+                                    egui::Layout::right_to_left(egui::Align::Center),
+                                    |ui| {
+                                        ui.strong(egui::RichText::new("Min (ms)").monospace());
+                                    },
+                                );
+                            });
+                            ui.scope(|ui| {
+                                ui.set_min_width(col_widths[3]);
+                                ui.with_layout(
+                                    egui::Layout::right_to_left(egui::Align::Center),
+                                    |ui| {
+                                        ui.strong(egui::RichText::new("Max (ms)").monospace());
+                                    },
+                                );
+                            });
+                            ui.scope(|ui| {
+                                ui.set_min_width(col_widths[4]);
+                                ui.with_layout(
+                                    egui::Layout::right_to_left(egui::Align::Center),
+                                    |ui| {
+                                        ui.strong(egui::RichText::new("Mean (ms)").monospace());
+                                    },
+                                );
+                            });
+                            ui.scope(|ui| {
+                                ui.set_min_width(col_widths[5]);
+                                ui.with_layout(
+                                    egui::Layout::right_to_left(egui::Align::Center),
+                                    |ui| {
+                                        ui.strong(egui::RichText::new("Median (ms)").monospace());
+                                    },
+                                );
+                            });
+                            ui.end_row();
+                        });
+
+                    // Add a horizontal separator line
+                    ui.separator();
+
+                    // Store the grid width and column percentages for the data grid
+                    ui.memory_mut(|mem| {
+                        mem.data.insert_temp(egui::Id::new("dependency_grid_width"), grid_width);
+                        mem.data.insert_temp(egui::Id::new("dependency_col_percentages"), col_percentages);
+                    });
+                }
+
+                // Results height
+                let results_height = if self.analysis_result.is_some() {
+                    (max_height - 400.0).max(200.0)
+                } else {
+                    100.0
+                };
+
+                // Grid contents in a scrollable area
+                ScrollArea::vertical()
+                    .max_height(results_height)
+                    .id_salt("dependency_results_scroll_area")
+                    .show_viewport(ui, |ui, _viewport| {
+                        if let Some(result) = &self.analysis_result {
+                            // Retrieve the stored grid width and column percentages
+                            let (grid_width, col_percentages) = ui.memory(|mem| {
+                                let width = mem.data.get_temp::<f32>(egui::Id::new("dependency_grid_width"))
+                                    .unwrap_or_else(|| ui.available_width());
+                                let percentages = mem.data.get_temp::<[f32; 6]>(egui::Id::new("dependency_col_percentages"))
+                                    .unwrap_or([0.25, 0.1, 0.15, 0.2, 0.15, 0.15]);
+                                (width, percentages)
+                            });
+
+                            // Calculate column widths using the same grid width and percentages
+                            let col_widths = [
+                                (grid_width * col_percentages[0]).max(140.0), // Node
+                                (grid_width * col_percentages[1]).max(60.0),  // Count
+                                (grid_width * col_percentages[2]).max(80.0),  // Min
+                                (grid_width * col_percentages[3]).max(80.0),  // Max
+                                (grid_width * col_percentages[4]).max(80.0),  // Mean
+                                (grid_width * col_percentages[5]).max(80.0),  // Median
+                            ];
+
+                            // Use Grid for tabular data (without headers)
+                            Grid::new("dependency_analysis_grid")
+                                .num_columns(6)
+                                .spacing([10.0, 6.0])
+                                .striped(true)
+                                .min_col_width(0.0) // Let the explicit width settings handle sizing
+                                .show(ui, |ui| {
+                                    // Get nodes and sort them alphabetically
+                                    let mut node_names: Vec<String> =
+                                        result.per_node_results.keys().cloned().collect();
+                                    node_names.sort();
+
+                                    // Rows for each node
+                                    for node_name in node_names {
+                                        if let Some(node_result) = result.per_node_results.get(&node_name) {
+                                            let stats = &node_result.statistics;
+
+                                            // Node Name + Focus Button Column
+                                            ui.scope(|ui| {
+                                                ui.set_min_width(col_widths[0]);
+                                                ui.horizontal(|ui| {
+                                                    ui.label(
+                                                        egui::RichText::new(&node_name).monospace(),
+                                                    );
+                                                    ui.add_space(5.0); // Padding
+                                                    let focus_response = ui.button("🔍");
+                                                    if focus_response.clicked() {
+                                                        self.focus_node = Some(node_name.clone());
+                                                        modal_closed = true;
+                                                    }
+                                                });
+                                            });
+
+                                            // Stats columns
+                                            if stats.count > 0 {
+                                                // Count
+                                                ui.scope(|ui| {
+                                                    ui.set_min_width(col_widths[1]);
+                                                    ui.with_layout(
+                                                        egui::Layout::right_to_left(egui::Align::Center),
+                                                        |ui| {
+                                                            ui.label(
+                                                                egui::RichText::new(format!("{}", stats.count))
+                                                                    .monospace(),
+                                                            );
+                                                        },
+                                                    );
+                                                });
+                                                // Min
+                                                ui.scope(|ui| {
+                                                    ui.set_min_width(col_widths[2]);
+                                                    ui.with_layout(
+                                                        egui::Layout::right_to_left(egui::Align::Center),
+                                                        |ui| {
+                                                            ui.label(
+                                                                egui::RichText::new(format!("{:.3}", stats.min * 1000.0))
+                                                                    .monospace()
+                                                                    .color(Color32::from_rgb(50, 150, 200)),
+                                                            );
+                                                        },
+                                                    );
+                                                });
+                                                // Max
+                                                ui.scope(|ui| {
+                                                    ui.set_min_width(col_widths[3]);
+                                                    ui.with_layout(
+                                                        egui::Layout::right_to_left(egui::Align::Center),
+                                                        |ui| {
+                                                            ui.label(
+                                                                egui::RichText::new(format!("{:.3}", stats.max * 1000.0))
+                                                                    .monospace()
+                                                                    .color(Color32::from_rgb(50, 150, 200)),
+                                                            );
+                                                        },
+                                                    );
+                                                });
+                                                // Mean
+                                                ui.scope(|ui| {
+                                                    ui.set_min_width(col_widths[4]);
+                                                    ui.with_layout(
+                                                        egui::Layout::right_to_left(egui::Align::Center),
+                                                        |ui| {
+                                                            ui.label(
+                                                                egui::RichText::new(format!("{:.3}", stats.mean() * 1000.0))
+                                                                    .monospace(),
+                                                            );
+                                                        },
+                                                    );
+                                                });
+                                                // Median
+                                                ui.scope(|ui| {
+                                                    ui.set_min_width(col_widths[5]);
+                                                    ui.with_layout(
+                                                        egui::Layout::right_to_left(egui::Align::Center),
+                                                        |ui| {
+                                                            ui.label(
+                                                                egui::RichText::new(format!("{:.3}", stats.median() * 1000.0)) // Corrected: median is also in ms
+                                                                    .monospace(),
+                                                            );
+                                                        },
+                                                    );
+                                                });
+                                            } else {
+                                                // No links for this node, display "-" for all stat columns (Count, Min, Max, Mean, Median)
+                                                for col_width in col_widths.iter().skip(1) { // Iterate for the 5 stat columns
+                                                    ui.scope(|ui| {
+                                                        ui.set_min_width(*col_width);
+                                                        ui.with_layout(
+                                                            egui::Layout::right_to_left(egui::Align::Center),
+                                                            |ui| {
+                                                                ui.label(
+                                                                    egui::RichText::new("-").monospace(),
+                                                                );
+                                                            },
+                                                        );
+                                                    });
+                                                }
+                                            }
+                                            ui.end_row();
+                                        }
+                                    }
+
+                                    // If no results found
+                                    if result.per_node_results.is_empty() {
+                                        ui.scope(|ui| {
+                                            ui.set_min_width(col_widths[0]);
+                                            ui.label(
+                                                egui::RichText::new("No matching dependencies found").monospace(),
+                                            );
+                                        });
+                                        for _ in 0..5 {
+                                            ui.scope(|ui| {
+                                                ui.set_min_width(col_widths[1]);
+                                                ui.label("");
+                                            });
+                                        }
+                                        ui.end_row();
+                                    }
+                                });
+                        } else {
+                            ui.label("Select source and target spans, then click 'Analyze' to see dependency statistics.");
+                        }
+                    });
+
+                ui.separator();
+
+                ui.add_space(10.0);
+                ui.horizontal(|ui| {
+                    if ui.button("Close").clicked() {
+                        modal_closed = true;
+                    }
+
+                    // Future: Add a "Focus" button here with magnifying glass icon
+                });
+            });
+        });
+
+        // Apply changes if modal closed
+        if modal_closed {
+            self.show = false;
+            self.spans_processed = false;
+            self.source_span_name = None;
+            self.target_span_name = None;
+            self.source_search_text = String::new();
+            self.target_search_text = String::new();
+            self.threshold = 1;
+            self.threshold_edit_str = self.threshold.to_string();
+            self.metadata_field = String::new();
+            self.source_scope = "self".to_string();
+            self.error_message = None;
+        }
+
+        // Check for ESC key to close the modal
+        ctx.input(|i| {
+            if i.key_pressed(Key::Escape) && self.show {
+                // Only act if modal was open
+                self.show = false;
+                // When closing with ESC, also reset state like the "Close" button does
+                self.spans_processed = false;
+                self.source_span_name = None;
+                self.target_span_name = None;
+                self.source_search_text = String::new();
+                self.target_search_text = String::new();
+                self.threshold = 1;
+                self.threshold_edit_str = self.threshold.to_string();
+                self.metadata_field = String::new();
+                self.source_scope = "self".to_string();
+                self.error_message = None;
+                // analysis_result and focus_node are intentionally not cleared here
+            }
+        });
+    }
+}

--- a/src/analyze_dependency.rs
+++ b/src/analyze_dependency.rs
@@ -106,6 +106,14 @@ impl AnalyzeDependencyModal {
         }
     }
 
+    pub fn open(&mut self, spans_for_analysis: &[Rc<Span>]) {
+        self.show = true;
+        self.source_search_text = String::new();
+        self.target_search_text = String::new();
+        self.update_span_list(spans_for_analysis);
+        self.spans_processed = true;
+    }
+
     pub fn update_span_list(&mut self, spans: &[Rc<Span>]) {
         let (all_spans, unique_names) = process_spans_for_analysis(spans);
         self.all_spans_for_analysis = all_spans;

--- a/src/analyze_dependency.rs
+++ b/src/analyze_dependency.rs
@@ -122,6 +122,15 @@ impl AnalyzeDependencyModal {
         self.focus_node = None;
     }
 
+    pub fn get_links_for_node(&self, node_name: &str) -> Option<&Vec<DependencyLink>> {
+        self.analysis_result.as_ref().and_then(|result| {
+            result
+                .per_node_results
+                .get(node_name)
+                .map(|metrics| &metrics.links)
+        })
+    }
+
     pub fn update_span_list(&mut self, spans: &[Rc<Span>]) {
         let (all_spans, unique_names) = process_spans_for_analysis(spans);
         self.all_spans_for_analysis = all_spans;

--- a/src/analyze_dependency.rs
+++ b/src/analyze_dependency.rs
@@ -407,21 +407,9 @@ impl AnalyzeDependencyModal {
     }
 
     // Show the modal
-    pub fn show_modal(
-        &mut self,
-        ctx: &egui::Context,
-        spans: &[Rc<Span>],
-        max_width: f32,
-        max_height: f32,
-    ) {
+    pub fn show_modal(&mut self, ctx: &egui::Context, max_width: f32, max_height: f32) {
         if !self.show {
             return;
-        }
-
-        // Only update the span list if we have new spans and they're not empty
-        if !self.spans_processed && !spans.is_empty() {
-            self.update_span_list(spans);
-            self.spans_processed = true;
         }
 
         let mut modal_closed = false;

--- a/src/analyze_dependency.rs
+++ b/src/analyze_dependency.rs
@@ -418,33 +418,32 @@ impl AnalyzeDependencyModal {
                 ui.heading("Analyze Dependency");
                 ui.add_space(10.0);
 
-                // Use a Grid for Source and Target span selection and lists
-                egui::Grid::new("source_target_grid")
+                Grid::new("source_target_grid")
                     .num_columns(2)
-                    .spacing([20.0, 10.0]) // Spacing between columns and rows
+                    .spacing([20.0, 10.0])
                     .striped(true)
                     .show(ui, |ui| {
                         // --- Row 1: Search Boxes ---
                         // Source span search
                         ui.vertical(|ui| {
-                            ui.set_width(max_width * 0.45); // Maintain overall width proportion
+                            ui.set_width(max_width * 0.45);
                             span_search_ui(
                                 ui,
                                 &mut self.source_search_text,
                                 "Source Span:",
                                 "Search source span",
-                                ui.available_width() // Use available width within the cell
+                                ui.available_width()
                             );
                         });
                         // Target span search
                         ui.vertical(|ui| {
-                            ui.set_width(max_width * 0.45); // Maintain overall width proportion
+                            ui.set_width(max_width * 0.45);
                             span_search_ui(
                                 ui,
                                 &mut self.target_search_text,
                                 "Target Span:",
                                 "Search target span",
-                                ui.available_width() // Use available width within the cell
+                                ui.available_width()
                             );
                         });
                         ui.end_row();
@@ -484,14 +483,13 @@ impl AnalyzeDependencyModal {
 
                 // Configuration row
                 ui.horizontal(|ui| {
-                    // Threshold input (integer, min 1)
+                    // Threshold input
                     ui.vertical(|ui| {
                         ui.horizontal(|ui| {
                             ui.label("Threshold:");
                             let response = ui.add(
                                 TextEdit::singleline(&mut self.threshold_edit_str)
                                     .desired_width(50.0)
-                                    .text_color(Color32::LIGHT_GRAY)
                             );
 
                             let mut commit_valid_input = false;
@@ -501,8 +499,9 @@ impl AnalyzeDependencyModal {
 
                             if commit_valid_input {
                                 if let Ok(value) = self.threshold_edit_str.parse::<usize>() {
-                                    self.threshold = value.max(1); // Ensure minimum of 1
-                                } // If parse fails, self.threshold remains, and string will be reset below
+                                    // Ensure minimum of 1
+                                    self.threshold = value.max(1);
+                                }
                                 // Always reset edit string from the (potentially updated) numeric value after commit attempt
                                 self.threshold_edit_str = self.threshold.to_string();
                             } else if response.changed() {
@@ -528,7 +527,6 @@ impl AnalyzeDependencyModal {
                                 TextEdit::singleline(&mut self.metadata_field)
                                     .desired_width(120.0)
                                     .hint_text("field name")
-                                    .text_color(Color32::LIGHT_GRAY)
                             );
 
                             if response.hovered() {
@@ -550,11 +548,12 @@ impl AnalyzeDependencyModal {
                                 .selected_text(self.source_scope.to_string())
                                 .width(80.0)
                                 .show_ui(ui, |ui| {
-                                    ui.selectable_value(&mut self.source_scope, SourceScope::SameNode, SourceScope::SameNode.to_string());
-                                    ui.selectable_value(&mut self.source_scope, SourceScope::AllNodes, SourceScope::AllNodes.to_string());
+                                    ui.selectable_value(&mut self.source_scope,
+                                        SourceScope::SameNode, SourceScope::SameNode.to_string());
+                                    ui.selectable_value(&mut self.source_scope,
+                                        SourceScope::AllNodes, SourceScope::AllNodes.to_string());
                                 });
 
-                            // Attach hover text to the ComboBox response itself
                             combo_box_response.response.on_hover_text("'self' only considers sources from the same node as target. 'all nodes' considers sources from any node.");
                         });
                     });
@@ -605,14 +604,14 @@ impl AnalyzeDependencyModal {
                     });
                 }
 
-                // Create the grid headers first outside the scroll area (to keep them visible)
+                // Create the grid headers outside the scroll area (to keep them visible)
                 if self.analysis_result.is_some() {
                     ui.add_space(10.0);
 
                     let available_width = ui.available_width();
 
                     // Define percentage-based column widths that sum exactly to 100%
-                    let col_percentages = [0.25, 0.1, 0.15, 0.2, 0.15, 0.15]; // Sums to 1.0
+                    let col_percentages = [0.25, 0.1, 0.15, 0.2, 0.15, 0.15];
 
                     let grid_width = available_width;
 
@@ -624,7 +623,7 @@ impl AnalyzeDependencyModal {
                         .num_columns(6)
                         .spacing([10.0, 6.0])
                         .striped(true)
-                        .min_col_width(0.0) // Let the explicit width settings handle sizing
+                        .min_col_width(0.0)
                         .show(ui, |ui_grid| {
                             draw_left_aligned_text_cell(ui_grid, col_widths[0], "Node", true);
                             draw_right_aligned_text_cell(ui_grid, col_widths[1], "Count", true, None);
@@ -645,14 +644,12 @@ impl AnalyzeDependencyModal {
                     });
                 }
 
-                // Results height
+                // Grid contents in a scrollable area
                 let results_height = if self.analysis_result.is_some() {
                     (max_height - 400.0).max(200.0)
                 } else {
                     100.0
                 };
-
-                // Grid contents in a scrollable area
                 ScrollArea::vertical()
                     .max_height(results_height)
                     .id_salt("dependency_results_scroll_area")
@@ -670,12 +667,11 @@ impl AnalyzeDependencyModal {
                             // Calculate column widths using the same grid width and percentages
                             let col_widths = calculate_table_column_widths(grid_width, &col_percentages);
 
-                            // Use Grid for tabular data (without headers)
                             Grid::new("dependency_analysis_grid")
                                 .num_columns(6)
                                 .spacing([10.0, 6.0])
                                 .striped(true)
-                                .min_col_width(0.0) // Let the explicit width settings handle sizing
+                                .min_col_width(0.0)
                                 .show(ui, |ui| {
                                     // Get nodes and sort them alphabetically
                                     let mut node_names: Vec<String> =
@@ -750,10 +746,10 @@ impl AnalyzeDependencyModal {
                                                 );
                                             } else {
                                                 // No links for this node, display "-" for all stat columns (Count, Min, Max, Mean, Median)
-                                                for col_idx in 1..=5 { // Iterate for the 5 stat columns
+                                                for width in col_widths.iter().skip(1) {
                                                     draw_right_aligned_text_cell(
                                                         ui,
-                                                        col_widths[col_idx],
+                                                        *width,
                                                         "-",
                                                         false,
                                                         None
@@ -767,8 +763,8 @@ impl AnalyzeDependencyModal {
                                     // If no results found
                                     if result.per_node_results.is_empty() {
                                         draw_left_aligned_text_cell(ui, col_widths[0], "No matching dependencies found", false);
-                                        for col_idx in 1..=5 { // Iterate for the 5 stat columns
-                                             draw_right_aligned_text_cell(ui, col_widths[col_idx], "", false, None);
+                                        for width in col_widths.iter().skip(1) {
+                                             draw_right_aligned_text_cell(ui, *width, "", false, None);
                                         }
                                         ui.end_row();
                                     }
@@ -789,7 +785,7 @@ impl AnalyzeDependencyModal {
             });
         });
 
-        // Apply changes if modal closed
+        // Reset fields if modal got closed
         if modal_closed {
             self.show = false;
             self.spans_processed = false;

--- a/src/analyze_dependency.rs
+++ b/src/analyze_dependency.rs
@@ -138,6 +138,8 @@ impl AnalyzeDependencyModal {
     }
 
     fn analyze_dependencies(&mut self) {
+        self.analysis_result = None;
+
         // Validate source and target span names
         let source_name = match &self.source_span_name {
             Some(name) => name.clone(),

--- a/src/analyze_span.rs
+++ b/src/analyze_span.rs
@@ -4,7 +4,7 @@ use eframe::egui::{
     Align, Align2, Button, Color32, Context, Grid, Id, Key, Label, Layout, Modal, Order, RichText,
     ScrollArea, Sense, Ui, Vec2, Window,
 };
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::rc::Rc;
 
 #[derive(Default)]
@@ -183,27 +183,10 @@ impl AnalyzeSpanModal {
         });
     }
 
-    /// Update span list and store spans internally.
     pub fn update_span_list(&mut self, spans: &[Rc<Span>]) {
-        self.all_spans_for_analysis.clear();
-
-        // Collect all spans including children
-        for span in spans {
-            analyze_utils::collect_span_tree_with_deduplication(
-                span,
-                &mut self.all_spans_for_analysis,
-            );
-        }
-
-        // Create a set of unique span names
-        let mut unique_span_names: HashSet<String> = HashSet::new();
-        for span in &self.all_spans_for_analysis {
-            unique_span_names.insert(span.name.clone());
-        }
-
-        // Convert to sorted vector
-        self.unique_span_names = unique_span_names.into_iter().collect();
-        self.unique_span_names.sort_by_key(|a| a.to_lowercase());
+        let (all_spans, unique_names) = analyze_utils::process_spans_for_analysis(spans);
+        self.all_spans_for_analysis = all_spans;
+        self.unique_span_names = unique_names;
     }
 
     fn perform_span_analysis(&mut self, target_span_name: &str) {

--- a/src/analyze_span.rs
+++ b/src/analyze_span.rs
@@ -575,7 +575,7 @@ impl AnalyzeSpanModal {
             });
         });
 
-        // Apply changes if modal got closed
+        // Reset fields if modal got closed
         if modal_closed {
             self.show = false;
             self.spans_processed = false;

--- a/src/analyze_span.rs
+++ b/src/analyze_span.rs
@@ -310,18 +310,30 @@ impl AnalyzeSpanModal {
                     ui.label(format!("Analysis of span: '{}'", result.span_name));
                 }
 
-                // Define consistent column widths
-                let col_widths = [140.0, 60.0, 100.0, 100.0, 100.0, 100.0];
-
                 // Create the grid headers first outside the scroll area (to keep them visible)
                 if self.analyzer.span_statistics.is_some() {
                     ui.add_space(10.0);
+
+                    // Calculate total available width
+                    let total_available_width = ui.available_width();
+
+                    // Define column widths based on available space while keeping minimums
+                    // First column is for node names, others are for values
+                    let col_widths = [
+                        (total_available_width * 0.25).max(140.0),  // Node name (25% but min 140px)
+                        (total_available_width * 0.1).max(60.0),    // Count (10% but min 60px)
+                        (total_available_width * 0.15).max(80.0),   // Min (15% but min 80px)
+                        (total_available_width * 0.15).max(80.0),   // Max (15% but min 80px)
+                        (total_available_width * 0.15).max(80.0),   // Mean (15% but min 80px)
+                        (total_available_width * 0.15).max(80.0),   // Median (15% but min 80px)
+                    ];
 
                     // Header row - outside scrollable area to make it sticky
                     Grid::new("span_analysis_header_grid")
                         .num_columns(6)
                         .spacing([10.0, 6.0])
                         .striped(true)
+                        .min_col_width(0.0) // Let the explicit width settings handle sizing
                         .show(ui, |ui| {
                             // Create header cells with consistent width and borders
                             ui.scope(|ui| {
@@ -386,11 +398,25 @@ impl AnalyzeSpanModal {
                     .id_salt("analysis_results_scroll_area")
                     .show_viewport(ui, |ui, _viewport| {
                         if let Some(result) = &self.analyzer.span_statistics {
+                            // Calculate total available width again (might be different inside the scroll area)
+                            let total_available_width = ui.available_width();
+
+                            // Define column widths based on available space while keeping minimums
+                            let col_widths = [
+                                (total_available_width * 0.25).max(140.0),  // Node name (25% but min 140px)
+                                (total_available_width * 0.1).max(60.0),    // Count (10% but min 60px)
+                                (total_available_width * 0.15).max(80.0),   // Min (15% but min 80px)
+                                (total_available_width * 0.15).max(80.0),   // Max (15% but min 80px)
+                                (total_available_width * 0.15).max(80.0),   // Mean (15% but min 80px)
+                                (total_available_width * 0.15).max(80.0),   // Median (15% but min 80px)
+                            ];
+
                             // Use Grid for tabular data (without headers)
                             Grid::new("span_analysis_grid")
                                 .num_columns(6)
                                 .spacing([10.0, 6.0])
                                 .striped(true)
+                                .min_col_width(0.0) // Let the explicit width settings handle sizing
                                 .show(ui, |ui| {
                                     // Get nodes and sort them alphabetically
                                     let mut node_names: Vec<String> =

--- a/src/analyze_span.rs
+++ b/src/analyze_span.rs
@@ -1,0 +1,597 @@
+use crate::types::Span;
+use eframe::egui::{self, Button, Color32, Grid, Key, Layout, Modal, ScrollArea, TextEdit, Vec2};
+use std::collections::{HashMap, HashSet};
+use std::rc::Rc;
+
+#[derive(Default)]
+pub struct AnalyzeSpanModal {
+    pub show: bool,
+    pub search_text: String,
+    pub selected_span_name: Option<String>,
+    pub unique_span_names: Vec<String>,
+    pub analyzer: SpanAnalyzer,
+    pub spans_processed: bool,
+    stored_spans: Vec<Rc<Span>>,
+}
+
+// Separate struct for handling span analysis to avoid borrow issues
+#[derive(Default)]
+pub struct SpanAnalyzer {
+    pub analyze_result: Option<String>,
+    span_statistics: Option<SpanAnalysisResult>,
+}
+
+// Struct to hold duration statistics for spans
+struct SpanStatistics {
+    count: usize,
+    max_duration: f64,
+    min_duration: f64,
+    total_duration: f64,
+    durations: Vec<f64>,
+}
+
+impl SpanStatistics {
+    fn new() -> Self {
+        Self {
+            count: 0,
+            max_duration: f64::MIN,
+            min_duration: f64::MAX,
+            total_duration: 0.0,
+            durations: Vec::new(),
+        }
+    }
+
+    fn add_span(&mut self, span: &Rc<Span>) {
+        let duration = span.end_time - span.start_time;
+        self.count += 1;
+        self.max_duration = self.max_duration.max(duration);
+        self.min_duration = self.min_duration.min(duration);
+        self.total_duration += duration;
+        self.durations.push(duration);
+    }
+
+    fn mean_duration(&self) -> f64 {
+        if self.count == 0 {
+            return 0.0;
+        }
+        self.total_duration / self.count as f64
+    }
+
+    fn median_duration(&self) -> f64 {
+        if self.durations.is_empty() {
+            return 0.0;
+        }
+
+        let mut sorted_durations = self.durations.clone();
+        sorted_durations.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+
+        let mid = sorted_durations.len() / 2;
+        if sorted_durations.len() % 2 == 0 {
+            (sorted_durations[mid - 1] + sorted_durations[mid]) / 2.0
+        } else {
+            sorted_durations[mid]
+        }
+    }
+}
+
+// Struct to hold analysis results for all nodes
+struct SpanAnalysisResult {
+    span_name: String,
+    per_node_stats: HashMap<String, SpanStatistics>,
+    overall_stats: SpanStatistics,
+}
+
+impl SpanAnalyzer {
+    // Analyze spans without requiring spans to be passed in each time
+    pub fn analyze_spans(&mut self, stored_spans: &[Rc<Span>], target_span_name: &str) {
+        // Collect all spans with the target name from all nodes
+        let mut matching_spans = Vec::new();
+        let target_name = target_span_name.to_string();
+
+        // Collect matching spans
+        collect_matching_spans(stored_spans, &target_name, &mut matching_spans);
+
+        if matching_spans.is_empty() {
+            self.analyze_result = Some(format!("No spans found with name '{}'", target_name));
+            return;
+        }
+
+        // Group spans by node
+        let mut per_node_stats: HashMap<String, SpanStatistics> = HashMap::new();
+        let mut overall_stats = SpanStatistics::new();
+
+        for span in matching_spans {
+            // Add to overall statistics
+            overall_stats.add_span(&span);
+
+            // Add to per-node statistics
+            let node_name = span.node.name.clone();
+            per_node_stats
+                .entry(node_name)
+                .or_insert_with(SpanStatistics::new)
+                .add_span(&span);
+        }
+
+        // Store the results
+        self.span_statistics = Some(SpanAnalysisResult {
+            span_name: target_name,
+            per_node_stats,
+            overall_stats,
+        });
+    }
+}
+
+impl AnalyzeSpanModal {
+    // Update span list and store spans internally
+    pub fn update_span_list(&mut self, spans: &[Rc<Span>]) {
+        // Store all spans including children
+        self.stored_spans.clear();
+
+        // Collect all spans including children
+        for span in spans {
+            collect_all_spans(span, &mut self.stored_spans);
+        }
+
+        println!(
+            "Stored {} spans in the analyze modal",
+            self.stored_spans.len()
+        );
+
+        // Create a set of unique span names
+        let mut unique_span_names: HashSet<String> = HashSet::new();
+
+        for span in &self.stored_spans {
+            unique_span_names.insert(span.name.clone());
+        }
+
+        // Convert to sorted vector
+        self.unique_span_names = unique_span_names.into_iter().collect();
+        self.unique_span_names.sort_by_key(|a| a.to_lowercase());
+    }
+
+    // Show the modal without requiring spans to be passed each time
+    pub fn show_modal(
+        &mut self,
+        ctx: &egui::Context,
+        spans: &[Rc<Span>],
+        max_width: f32,
+        max_height: f32,
+    ) {
+        if !self.show {
+            return;
+        }
+
+        // Only update the span list if we have new spans and they're not empty
+        if !self.spans_processed && !spans.is_empty() {
+            self.update_span_list(spans);
+            self.spans_processed = true;
+        }
+
+        let mut modal_closed = false;
+
+        Modal::new("analyze span".into()).show(ctx, |ui| {
+            ui.vertical(|ui| {
+                ui.set_max_width(max_width);
+                ui.set_max_height(max_height);
+
+                ui.heading("Analyze Span");
+
+                // Top row with search and analyze button
+                ui.horizontal(|ui| {
+                    // Search field (left side, takes 70% of width)
+                    ui.with_layout(Layout::left_to_right(eframe::emath::Align::Center), |ui| {
+                        ui.set_max_width(max_width * 0.7);
+                        ui.vertical(|ui| {
+                            ui.label("Search span by name:");
+                            let text_edit = TextEdit::singleline(&mut self.search_text)
+                                .hint_text("Type to search")
+                                .background_color(Color32::from_gray(40))
+                                .desired_width(max_width * 0.65);
+                            ui.add(text_edit);
+                        });
+                    });
+
+                    // Analyze button (right side)
+                    ui.with_layout(Layout::right_to_left(eframe::emath::Align::Center), |ui| {
+                        let is_span_selected = self.selected_span_name.is_some();
+                        if ui
+                            .add_enabled(
+                                is_span_selected,
+                                Button::new("Analyze").min_size(Vec2::new(120.0, 40.0)),
+                            )
+                            .clicked()
+                        {
+                            if let Some(span_name) = &self.selected_span_name {
+                                // Run the actual analysis when the button is clicked
+                                // Use stored_spans instead of passing them from outside
+                                self.analyzer.analyze_spans(&self.stored_spans, span_name);
+                            }
+                        }
+                    });
+                });
+
+                ui.add_space(10.0);
+
+                // Filter names by the search text
+                let search_term = self.search_text.to_lowercase();
+                let filtered_names: Vec<&String> = self
+                    .unique_span_names
+                    .iter()
+                    .filter(|name| {
+                        search_term.is_empty() || name.to_lowercase().contains(&search_term)
+                    })
+                    .collect();
+
+                // Split the remaining space - List takes 30% of height
+                let list_height = (max_height - 120.0) * 0.3;
+                let results_height = (max_height - 120.0) * 0.7 - 20.0;
+
+                // Show list of span names in a scrollable area
+                ui.label(format!("Spans ({}):", filtered_names.len()));
+
+                // Make sure we always have a scrollbar for the list
+                ScrollArea::vertical()
+                    .max_height(list_height)
+                    .id_salt("spans_list_scroll_area")
+                    .show_viewport(ui, |ui, _viewport| {
+                        for name in &filtered_names {
+                            let is_selected = self.selected_span_name.as_ref() == Some(name);
+
+                            let response = ui.selectable_label(is_selected, *name);
+
+                            if response.clicked() {
+                                self.selected_span_name = Some((*name).clone());
+                                self.analyzer.span_statistics = None;
+                            }
+                        }
+                    });
+
+                ui.separator();
+
+                // Results area
+                ui.label("Analysis Results:");
+
+                if let Some(result) = &self.analyzer.span_statistics {
+                    ui.label(format!("Analysis of span: '{}'", result.span_name));
+                }
+
+                // Define consistent column widths
+                let col_widths = [140.0, 60.0, 100.0, 100.0, 100.0, 100.0];
+
+                // Create the grid headers first outside the scroll area (to keep them visible)
+                if self.analyzer.span_statistics.is_some() {
+                    ui.add_space(10.0);
+
+                    // Header row - outside scrollable area to make it sticky
+                    Grid::new("span_analysis_header_grid")
+                        .num_columns(6)
+                        .spacing([10.0, 6.0])
+                        .striped(true)
+                        .show(ui, |ui| {
+                            // Create header cells with consistent width and borders
+                            ui.scope(|ui| {
+                                ui.set_min_width(col_widths[0]);
+                                ui.strong(egui::RichText::new("Node").monospace());
+                            });
+                            ui.scope(|ui| {
+                                ui.set_min_width(col_widths[1]);
+                                ui.with_layout(
+                                    egui::Layout::right_to_left(egui::Align::Center),
+                                    |ui| {
+                                        ui.strong(egui::RichText::new("Count").monospace());
+                                    },
+                                );
+                            });
+                            ui.scope(|ui| {
+                                ui.set_min_width(col_widths[2]);
+                                ui.with_layout(
+                                    egui::Layout::right_to_left(egui::Align::Center),
+                                    |ui| {
+                                        ui.strong(egui::RichText::new("Min (ms)").monospace());
+                                    },
+                                );
+                            });
+                            ui.scope(|ui| {
+                                ui.set_min_width(col_widths[3]);
+                                ui.with_layout(
+                                    egui::Layout::right_to_left(egui::Align::Center),
+                                    |ui| {
+                                        ui.strong(egui::RichText::new("Max (ms)").monospace());
+                                    },
+                                );
+                            });
+                            ui.scope(|ui| {
+                                ui.set_min_width(col_widths[4]);
+                                ui.with_layout(
+                                    egui::Layout::right_to_left(egui::Align::Center),
+                                    |ui| {
+                                        ui.strong(egui::RichText::new("Mean (ms)").monospace());
+                                    },
+                                );
+                            });
+                            ui.scope(|ui| {
+                                ui.set_min_width(col_widths[5]);
+                                ui.with_layout(
+                                    egui::Layout::right_to_left(egui::Align::Center),
+                                    |ui| {
+                                        ui.strong(egui::RichText::new("Median (ms)").monospace());
+                                    },
+                                );
+                            });
+                            ui.end_row();
+                        });
+
+                    // Add a horizontal separator line
+                    ui.separator();
+                }
+
+                // Grid contents in a scrollable area
+                ScrollArea::vertical()
+                    .max_height(results_height)
+                    .id_salt("analysis_results_scroll_area")
+                    .show_viewport(ui, |ui, _viewport| {
+                        if let Some(result) = &self.analyzer.span_statistics {
+                            // Use Grid for tabular data (without headers)
+                            Grid::new("span_analysis_grid")
+                                .num_columns(6)
+                                .spacing([10.0, 6.0])
+                                .striped(true)
+                                .show(ui, |ui| {
+                                    // Get nodes and sort them alphabetically
+                                    let mut node_names: Vec<String> =
+                                        result.per_node_stats.keys().cloned().collect();
+                                    node_names.sort();
+
+                                    // Rows for each node
+                                    for node_name in node_names {
+                                        if let Some(stats) = result.per_node_stats.get(&node_name) {
+                                            // Apply consistent width to each cell with monospace font
+                                            ui.scope(|ui| {
+                                                ui.set_min_width(col_widths[0]);
+                                                ui.label(
+                                                    egui::RichText::new(&node_name).monospace(),
+                                                );
+                                            });
+                                            ui.scope(|ui| {
+                                                ui.set_min_width(col_widths[1]);
+                                                ui.with_layout(
+                                                    egui::Layout::right_to_left(
+                                                        egui::Align::Center,
+                                                    ),
+                                                    |ui| {
+                                                        ui.label(
+                                                            egui::RichText::new(format!(
+                                                                "{}",
+                                                                stats.count
+                                                            ))
+                                                            .monospace(),
+                                                        );
+                                                    },
+                                                );
+                                            });
+                                            ui.scope(|ui| {
+                                                ui.set_min_width(col_widths[2]);
+                                                ui.with_layout(
+                                                    egui::Layout::right_to_left(
+                                                        egui::Align::Center,
+                                                    ),
+                                                    |ui| {
+                                                        ui.label(
+                                                            egui::RichText::new(format!(
+                                                                "{:.3}",
+                                                                stats.min_duration * 1000.0
+                                                            ))
+                                                            .monospace(),
+                                                        );
+                                                    },
+                                                );
+                                            });
+                                            ui.scope(|ui| {
+                                                ui.set_min_width(col_widths[3]);
+                                                ui.with_layout(
+                                                    egui::Layout::right_to_left(
+                                                        egui::Align::Center,
+                                                    ),
+                                                    |ui| {
+                                                        ui.label(
+                                                            egui::RichText::new(format!(
+                                                                "{:.3}",
+                                                                stats.max_duration * 1000.0
+                                                            ))
+                                                            .monospace(),
+                                                        );
+                                                    },
+                                                );
+                                            });
+                                            ui.scope(|ui| {
+                                                ui.set_min_width(col_widths[4]);
+                                                ui.with_layout(
+                                                    egui::Layout::right_to_left(
+                                                        egui::Align::Center,
+                                                    ),
+                                                    |ui| {
+                                                        ui.label(
+                                                            egui::RichText::new(format!(
+                                                                "{:.3}",
+                                                                stats.mean_duration() * 1000.0
+                                                            ))
+                                                            .monospace(),
+                                                        );
+                                                    },
+                                                );
+                                            });
+                                            ui.scope(|ui| {
+                                                ui.set_min_width(col_widths[5]);
+                                                ui.with_layout(
+                                                    egui::Layout::right_to_left(
+                                                        egui::Align::Center,
+                                                    ),
+                                                    |ui| {
+                                                        ui.label(
+                                                            egui::RichText::new(format!(
+                                                                "{:.3}",
+                                                                stats.median_duration() * 1000.0
+                                                            ))
+                                                            .monospace(),
+                                                        );
+                                                    },
+                                                );
+                                            });
+                                            ui.end_row();
+                                        }
+                                    }
+
+                                    // Overall statistics row
+                                    let overall = &result.overall_stats;
+                                    ui.scope(|ui| {
+                                        ui.set_min_width(col_widths[0]);
+                                        ui.strong(egui::RichText::new("ALL NODES").monospace());
+                                    });
+                                    ui.scope(|ui| {
+                                        ui.set_min_width(col_widths[1]);
+                                        ui.with_layout(
+                                            egui::Layout::right_to_left(egui::Align::Center),
+                                            |ui| {
+                                                ui.strong(
+                                                    egui::RichText::new(format!(
+                                                        "{}",
+                                                        overall.count
+                                                    ))
+                                                    .monospace(),
+                                                );
+                                            },
+                                        );
+                                    });
+                                    ui.scope(|ui| {
+                                        ui.set_min_width(col_widths[2]);
+                                        ui.with_layout(
+                                            egui::Layout::right_to_left(egui::Align::Center),
+                                            |ui| {
+                                                ui.strong(
+                                                    egui::RichText::new(format!(
+                                                        "{:.3}",
+                                                        overall.min_duration * 1000.0
+                                                    ))
+                                                    .monospace(),
+                                                );
+                                            },
+                                        );
+                                    });
+                                    ui.scope(|ui| {
+                                        ui.set_min_width(col_widths[3]);
+                                        ui.with_layout(
+                                            egui::Layout::right_to_left(egui::Align::Center),
+                                            |ui| {
+                                                ui.strong(
+                                                    egui::RichText::new(format!(
+                                                        "{:.3}",
+                                                        overall.max_duration * 1000.0
+                                                    ))
+                                                    .monospace(),
+                                                );
+                                            },
+                                        );
+                                    });
+                                    ui.scope(|ui| {
+                                        ui.set_min_width(col_widths[4]);
+                                        ui.with_layout(
+                                            egui::Layout::right_to_left(egui::Align::Center),
+                                            |ui| {
+                                                ui.strong(
+                                                    egui::RichText::new(format!(
+                                                        "{:.3}",
+                                                        overall.mean_duration() * 1000.0
+                                                    ))
+                                                    .monospace(),
+                                                );
+                                            },
+                                        );
+                                    });
+                                    ui.scope(|ui| {
+                                        ui.set_min_width(col_widths[5]);
+                                        ui.with_layout(
+                                            egui::Layout::right_to_left(egui::Align::Center),
+                                            |ui| {
+                                                ui.strong(
+                                                    egui::RichText::new(format!(
+                                                        "{:.3}",
+                                                        overall.median_duration() * 1000.0
+                                                    ))
+                                                    .monospace(),
+                                                );
+                                            },
+                                        );
+                                    });
+                                    ui.end_row();
+                                });
+                        } else if self.selected_span_name.is_some() {
+                            ui.label("Click 'Analyze' to see statistics for the selected span.");
+                        } else {
+                            ui.label("Select a span from the list to analyze.");
+                        }
+                    });
+
+                ui.separator();
+
+                // Only Close button at the bottom
+                if ui.button("Close").clicked() {
+                    modal_closed = true;
+                }
+            });
+        });
+
+        // Close with Escape key
+        ctx.input(|i| {
+            if i.key_down(Key::Escape) {
+                modal_closed = true;
+            }
+        });
+
+        // Apply changes if modal closed
+        // Reset all selections
+        if modal_closed {
+            self.show = false;
+            self.spans_processed = false;
+            self.selected_span_name = None;
+            self.search_text = String::new();
+            self.analyzer.span_statistics = None;
+        }
+    }
+}
+
+// Helper function to collect all existing spans.
+fn collect_all_spans(span: &Rc<Span>, all_spans: &mut Vec<Rc<Span>>) {
+    // Use a HashSet to track span IDs we've already collected
+    let mut seen_span_ids: HashSet<Vec<u8>> = HashSet::new();
+    collect_all_spans_with_deduplication(span, all_spans, &mut seen_span_ids);
+}
+
+fn collect_all_spans_with_deduplication(
+    span: &Rc<Span>,
+    all_spans: &mut Vec<Rc<Span>>,
+    seen_span_ids: &mut HashSet<Vec<u8>>,
+) {
+    // Only add this span if we haven't seen its ID before
+    if !seen_span_ids.contains(&span.span_id) {
+        seen_span_ids.insert(span.span_id.clone());
+        all_spans.push(span.clone());
+        // Recursively add all children
+        for child in span.children.borrow().iter() {
+            collect_all_spans_with_deduplication(child, all_spans, seen_span_ids);
+        }
+    }
+}
+
+fn collect_matching_spans(
+    spans: &[Rc<Span>],
+    target_name: &str,
+    matching_spans: &mut Vec<Rc<Span>>,
+) {
+    // Since the input spans are already deduplicated, we can simply filter
+    // for spans with matching names
+    for span in spans {
+        if span.name == target_name {
+            matching_spans.push(span.clone());
+        }
+    }
+}

--- a/src/analyze_span.rs
+++ b/src/analyze_span.rs
@@ -16,11 +16,11 @@ pub struct AnalyzeSpanModal {
     /// Whether the modal window is currently visible.
     pub show: bool,
     /// Text entered by the user in the span name search box.
-    pub search_text: String,
+    search_text: String,
     /// The name of the span currently selected by the user in the list.
-    pub selected_span_name: Option<String>,
+    selected_span_name: Option<String>,
     /// A sorted list of unique span names found in the current trace data.
-    pub unique_span_names: Vec<String>,
+    unique_span_names: Vec<String>,
     /// Flag indicating if the span list for the modal has been processed from the current trace data.
     pub spans_processed: bool,
     /// All unique spans (including children) collected from the current trace, used for analysis.
@@ -28,7 +28,7 @@ pub struct AnalyzeSpanModal {
     /// Stores the specific span whose details are to be shown in a separate popup, if any.
     span_details: Option<Rc<Span>>,
     /// An optional message summarizing the outcome of the last analysis (e.g., errors or warnings).
-    pub analysis_summary_message: Option<String>,
+    analysis_summary_message: Option<String>,
     /// Stores the detailed results of the last span analysis performed.
     detailed_span_analysis: Option<SpanAnalysisResult>,
 }
@@ -147,6 +147,10 @@ impl AnalyzeSpanModal {
         self.search_text = String::new();
         self.update_span_list(spans_for_analysis);
         self.spans_processed = true;
+    }
+
+    pub fn reset_processed_flag(&mut self) {
+        self.spans_processed = false;
     }
 
     pub fn update_span_list(&mut self, spans: &[Rc<Span>]) {

--- a/src/analyze_span.rs
+++ b/src/analyze_span.rs
@@ -246,8 +246,8 @@ impl AnalyzeSpanModal {
                 // These will be properly set if detailed_span_analysis is Some,
                 // and the ScrollArea that uses them is only shown in that case.
                 let mut grid_width = 0.0;
-                // Define percentage-based column widths that sum exactly to 100%
-                let col_percentages = [0.25, 0.1, 0.15, 0.15, 0.15, 0.2]; // Node, Count, Min, Max, Mean, Median
+                // Define percentage-based column widths
+                let col_percentages = [0.25, 0.14, 0.14, 0.14, 0.14, 0.14]; // Node, Count, Min, Max, Mean, Median
 
                 // Top row with search and analyze button
                 ui.horizontal(|ui| {

--- a/src/analyze_span.rs
+++ b/src/analyze_span.rs
@@ -142,6 +142,13 @@ impl AnalyzeSpanModal {
         });
     }
 
+    pub fn open(&mut self, spans_for_analysis: &[Rc<Span>]) {
+        self.show = true;
+        self.search_text = String::new();
+        self.update_span_list(spans_for_analysis);
+        self.spans_processed = true;
+    }
+
     pub fn update_span_list(&mut self, spans: &[Rc<Span>]) {
         let (all_spans, unique_names) = process_spans_for_analysis(spans);
         self.all_spans_for_analysis = all_spans;

--- a/src/analyze_span.rs
+++ b/src/analyze_span.rs
@@ -22,7 +22,7 @@ pub struct AnalyzeSpanModal {
     /// A sorted list of unique span names found in the current trace data.
     unique_span_names: Vec<String>,
     /// Flag indicating if the span list for the modal has been processed from the current trace data.
-    pub spans_processed: bool,
+    spans_processed: bool,
     /// All unique spans (including children) collected from the current trace, used for analysis.
     all_spans_for_analysis: Vec<Rc<Span>>,
     /// Stores the specific span whose details are to be shown in a separate popup, if any.
@@ -37,7 +37,6 @@ pub struct AnalyzeSpanModal {
 /// Also stores references to the spans with the min duration and max duration.
 struct SpanStatistics {
     duration_stats: Statistics,
-
     min_span: Option<Rc<Span>>,
     max_span: Option<Rc<Span>>,
 }
@@ -226,21 +225,9 @@ impl AnalyzeSpanModal {
             })
     }
 
-    pub fn show_modal(
-        &mut self,
-        ctx: &Context,
-        spans: &[Rc<Span>],
-        max_width: f32,
-        max_height: f32,
-    ) {
+    pub fn show_modal(&mut self, ctx: &Context, max_width: f32, max_height: f32) {
         if !self.show {
             return;
-        }
-
-        // Only update the span list if we have new spans and they're not empty
-        if !self.spans_processed && !spans.is_empty() {
-            self.update_span_list(spans);
-            self.spans_processed = true;
         }
 
         // Track if we need to view a span's details after modal closes
@@ -589,7 +576,6 @@ impl AnalyzeSpanModal {
         // Reset fields if modal got closed
         if modal_closed {
             self.show = false;
-            self.spans_processed = false;
             self.selected_span_name = None;
             self.search_text = String::new();
             self.detailed_span_analysis = None;

--- a/src/analyze_utils.rs
+++ b/src/analyze_utils.rs
@@ -1,0 +1,152 @@
+use crate::types::Span;
+use eframe::egui::{self, Color32, ScrollArea, TextEdit};
+use std::collections::HashSet;
+use std::rc::Rc;
+
+// Helper function to collect all existing spans with deduplication
+pub fn collect_all_spans(span: &Rc<Span>, all_spans: &mut Vec<Rc<Span>>) {
+    // Use a HashSet to track span IDs we've already collected
+    let mut seen_span_ids: HashSet<Vec<u8>> = HashSet::new();
+    collect_all_spans_with_deduplication(span, all_spans, &mut seen_span_ids);
+}
+
+fn collect_all_spans_with_deduplication(
+    span: &Rc<Span>,
+    all_spans: &mut Vec<Rc<Span>>,
+    seen_span_ids: &mut HashSet<Vec<u8>>,
+) {
+    // Only add this span if we haven't seen its ID before
+    if !seen_span_ids.contains(&span.span_id) {
+        seen_span_ids.insert(span.span_id.clone());
+        all_spans.push(span.clone());
+        // Recursively add all children
+        for child in span.children.borrow().iter() {
+            collect_all_spans_with_deduplication(child, all_spans, seen_span_ids);
+        }
+    }
+}
+
+// Helper function to collect spans with specific name
+pub fn collect_matching_spans(
+    spans: &[Rc<Span>],
+    target_name: &str,
+    matching_spans: &mut Vec<Rc<Span>>,
+) {
+    // Since the input spans are already deduplicated, we can simply filter
+    // for spans with matching names
+    for span in spans {
+        if span.name == target_name {
+            matching_spans.push(span.clone());
+        }
+    }
+}
+
+// Reusable search box UI component
+pub fn span_search_ui(
+    ui: &mut egui::Ui,
+    search_text: &mut String,
+    label: &str,
+    hint_text: &str,
+    width: f32,
+) {
+    ui.vertical(|ui| {
+        ui.label(label);
+        let text_edit = TextEdit::singleline(search_text)
+            .hint_text(hint_text)
+            .text_color(Color32::DARK_GRAY)
+            .desired_width(width);
+        ui.add(text_edit);
+    });
+}
+
+// Reusable span selection list UI component
+pub fn span_selection_list_ui(
+    ui: &mut egui::Ui,
+    unique_span_names: &[String],
+    search_text: &str,
+    selected_span_name: &mut Option<String>,
+    height: f32,
+    id_salt: &str,
+) -> bool {
+    let mut selection_changed = false;
+
+    // Filter names by the search text
+    let search_term = search_text.to_lowercase();
+    let filtered_names: Vec<&String> = unique_span_names
+        .iter()
+        .filter(|name| search_term.is_empty() || name.to_lowercase().contains(&search_term))
+        .collect();
+
+    // Label with count
+    ui.label(format!("Spans ({}):", filtered_names.len()));
+
+    // Scrollable list of spans
+    ScrollArea::vertical()
+        .max_height(height)
+        .id_salt(id_salt)
+        .show_viewport(ui, |ui, _viewport| {
+            for name in &filtered_names {
+                let is_selected = selected_span_name.as_ref() == Some(name);
+                let response = ui.selectable_label(is_selected, *name);
+
+                if response.clicked() {
+                    *selected_span_name = Some((*name).clone());
+                    selection_changed = true;
+                }
+            }
+        });
+
+    selection_changed
+}
+
+// Calculate statistics for a collection of values
+pub struct Statistics {
+    pub count: usize,
+    pub min: f64,
+    pub max: f64,
+    pub total: f64,
+    pub values: Vec<f64>,
+}
+
+impl Statistics {
+    pub fn new() -> Self {
+        Self {
+            count: 0,
+            min: f64::MAX,
+            max: f64::MIN,
+            total: 0.0,
+            values: Vec::new(),
+        }
+    }
+
+    pub fn add_value(&mut self, value: f64) {
+        self.count += 1;
+        self.min = self.min.min(value);
+        self.max = self.max.max(value);
+        self.total += value;
+        self.values.push(value);
+    }
+
+    pub fn mean(&self) -> f64 {
+        if self.count == 0 {
+            return 0.0;
+        }
+        self.total / self.count as f64
+    }
+
+    pub fn median(&self) -> f64 {
+        if self.values.is_empty() {
+            return 0.0;
+        }
+
+        let mut sorted_values = self.values.clone();
+        sorted_values.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+
+        let mid = sorted_values.len() / 2;
+        if sorted_values.len() % 2 == 0 {
+            (sorted_values[mid - 1] + sorted_values[mid]) / 2.0
+        } else {
+            sorted_values[mid]
+        }
+    }
+}

--- a/src/analyze_utils.rs
+++ b/src/analyze_utils.rs
@@ -152,3 +152,34 @@ impl Statistics {
         }
     }
 }
+
+/// Processes a slice of spans to collect a deduplicated list of all spans (including children)
+/// and a sorted list of unique span names.
+///
+/// # Arguments
+/// * `spans` - A slice of root spans to process.
+///
+/// # Returns
+/// A tuple containing:
+///  - `Vec<Rc<Span>>`: All collected spans, including children, deduplicated.
+///  - `Vec<String>`: A sorted vector of unique span names.
+pub fn process_spans_for_analysis(spans: &[Rc<Span>]) -> (Vec<Rc<Span>>, Vec<String>) {
+    let mut all_spans_for_analysis = Vec::new();
+
+    // Collect all spans including children
+    for span in spans {
+        collect_span_tree_with_deduplication(span, &mut all_spans_for_analysis);
+    }
+
+    // Create a set of unique span names
+    let mut unique_span_names_set: HashSet<String> = HashSet::new();
+    for span in &all_spans_for_analysis {
+        unique_span_names_set.insert(span.name.clone());
+    }
+
+    // Convert to sorted vector
+    let mut unique_span_names_vec: Vec<String> = unique_span_names_set.into_iter().collect();
+    unique_span_names_vec.sort_by_key(|a| a.to_lowercase());
+
+    (all_spans_for_analysis, unique_span_names_vec)
+}

--- a/src/analyze_utils.rs
+++ b/src/analyze_utils.rs
@@ -3,7 +3,7 @@ use eframe::egui::{self, Color32, ScrollArea, TextEdit};
 use std::collections::HashSet;
 use std::rc::Rc;
 
-// Helper function to collect all spans in a span tree with deduplication
+/// Helper function to collect all spans in a span tree with deduplication (the same span won't appear twice).
 pub fn collect_span_tree_with_deduplication(
     root_span: &Rc<Span>,
     collected_spans: &mut Vec<Rc<Span>>,
@@ -28,7 +28,7 @@ fn collect_descendant_spans_with_deduplication(
     }
 }
 
-// Helper function to collect spans with specific name
+/// Helper function to collect spans with specific name.
 pub fn collect_matching_spans(
     spans: &[Rc<Span>],
     target_name: &str,
@@ -41,7 +41,7 @@ pub fn collect_matching_spans(
     }
 }
 
-// Creates a search input field with a label and hint text
+/// Creates a search input field with a label and hint text.
 pub fn span_search_ui(
     ui: &mut egui::Ui,
     search_text: &mut String,
@@ -59,8 +59,9 @@ pub fn span_search_ui(
     });
 }
 
-// Creates a scrollable list of selectable span names with search filtering
-// Returns true if the user selected a different span name in this frame
+/// Creates a scrollable list of selectable span names with search filtering.
+///
+/// Returns true if the user selected a different span name in this frame.
 pub fn span_selection_list_ui(
     ui: &mut egui::Ui,
     unique_span_names: &[String],
@@ -100,7 +101,7 @@ pub fn span_selection_list_ui(
     selection_changed
 }
 
-// Calculate statistics for a collection of values
+/// Stores and calculates statistics for a collection of values.
 pub struct Statistics {
     pub count: usize,
     pub min: f64,

--- a/src/analyze_utils.rs
+++ b/src/analyze_utils.rs
@@ -1,5 +1,9 @@
 use crate::types::Span;
-use eframe::egui::{self, Color32, ScrollArea, TextEdit};
+use crate::types::MILLISECONDS_PER_SECOND;
+use eframe::egui::{
+    self, Align, Align2, Color32, Context, Grid, Key, Layout, Order, RichText, ScrollArea,
+    TextEdit, Ui,
+};
 use std::collections::HashSet;
 use std::rc::Rc;
 
@@ -182,4 +186,163 @@ pub fn process_spans_for_analysis(spans: &[Rc<Span>]) -> (Vec<Rc<Span>>, Vec<Str
     unique_span_names_vec.sort_by_key(|a| a.to_lowercase());
 
     (all_spans_for_analysis, unique_span_names_vec)
+}
+
+/// Calculates column widths for the analysis result table based on a total grid width and percentage array.
+/// Ensures minimum widths for each column.
+pub fn calculate_table_column_widths(grid_width: f32, col_percentages: &[f32; 6]) -> [f32; 6] {
+    [
+        (grid_width * col_percentages[0]).max(140.0), // Node/Source
+        (grid_width * col_percentages[1]).max(60.0),  // Count
+        (grid_width * col_percentages[2]).max(80.0),  // Min
+        (grid_width * col_percentages[3]).max(80.0),  // Max
+        (grid_width * col_percentages[4]).max(80.0),  // Mean
+        (grid_width * col_percentages[5]).max(80.0),  // Median
+    ]
+}
+
+/// Helper function to draw a left-aligned text cell, often used for names or labels.
+pub fn draw_left_aligned_text_cell(ui: &mut Ui, width: f32, text: &str, is_strong: bool) {
+    ui.scope(|cell_ui| {
+        cell_ui.set_min_width(width);
+        let rich_text = RichText::new(text).monospace();
+        if is_strong {
+            cell_ui.strong(rich_text);
+        } else {
+            cell_ui.label(rich_text);
+        }
+    });
+}
+
+/// Helper function to draw a right-aligned text cell, often used for numerical statistics.
+pub fn draw_right_aligned_text_cell(
+    ui: &mut Ui,
+    width: f32,
+    text: &str,
+    is_strong: bool,
+    color: Option<Color32>,
+) {
+    ui.scope(|cell_ui| {
+        cell_ui.set_min_width(width);
+        cell_ui.with_layout(Layout::right_to_left(Align::Center), |inner_ui| {
+            let mut rich_text = RichText::new(text).monospace();
+            if let Some(c) = color {
+                rich_text = rich_text.color(c);
+            }
+            if is_strong {
+                inner_ui.strong(rich_text);
+            } else {
+                inner_ui.label(rich_text);
+            }
+        });
+    });
+}
+
+/// Show details of a specific span in a new window.
+/// Returns true if the window was closed.
+pub fn show_span_details(ctx: &Context, span: &Rc<Span>, max_width: f32, max_height: f32) -> bool {
+    let mut should_close = false;
+
+    // Create a modal dialog for the span details
+    let mut open = true;
+    egui::Window::new("Span Details")
+        .fixed_size([max_width * 0.8, max_height * 0.6])
+        .collapsible(false)
+        .resizable(false)
+        .open(&mut open)
+        .anchor(Align2::CENTER_CENTER, [0.0, 0.0])
+        .order(Order::Foreground)
+        .show(ctx, |ui| {
+            ui.vertical_centered_justified(|ui| {
+                ui.heading(&span.name);
+                ui.add_space(10.0);
+
+                // Display timing information
+                ui.strong(format!(
+                    "Duration: {:.3} ms",
+                    (span.end_time - span.start_time) * MILLISECONDS_PER_SECOND
+                ));
+                ui.label(format!(
+                    "Time: {} - {}",
+                    crate::types::time_point_to_utc_string(span.start_time),
+                    crate::types::time_point_to_utc_string(span.end_time)
+                ));
+
+                // Display span identification
+                ui.add_space(5.0);
+                ui.label(format!("Node: {}", span.node.name));
+                ui.label(format!("Span ID: {}", hex::encode(&span.span_id)));
+                ui.label(format!(
+                    "Parent Span ID: {}",
+                    hex::encode(&span.parent_span_id)
+                ));
+
+                ui.add_space(10.0);
+                ui.separator();
+                ui.add_space(10.0);
+
+                // Display attributes
+                ui.heading("Attributes");
+                if span.attributes.is_empty() {
+                    ui.label("No attributes");
+                } else {
+                    Grid::new("span_details_attributes")
+                        .num_columns(2)
+                        .spacing([10.0, 6.0])
+                        .striped(true)
+                        .show(ui, |ui| {
+                            for (name, value) in &span.attributes {
+                                ui.strong(name);
+                                ui.label(crate::types::value_to_text(value));
+                                ui.end_row();
+                            }
+                        });
+                }
+
+                ui.add_space(10.0);
+                ui.separator();
+                ui.add_space(10.0);
+
+                // Display events
+                ui.heading("Events");
+                ScrollArea::vertical()
+                    .max_height(max_height * 0.3)
+                    .show(ui, |ui| {
+                        if span.events.is_empty() {
+                            ui.label("No events");
+                        } else {
+                            for event in &span.events {
+                                ui.collapsing(event.name.clone(), |ui| {
+                                    ui.label(format!(
+                                        "Time: {}",
+                                        crate::types::time_point_to_utc_string(event.time)
+                                    ));
+
+                                    for (name, value) in &event.attributes {
+                                        ui.label(format!(
+                                            "{}: {}",
+                                            name,
+                                            crate::types::value_to_text(value)
+                                        ));
+                                    }
+                                });
+                            }
+                        }
+                    });
+
+                ui.add_space(10.0);
+                if ui.button("Close").clicked() {
+                    should_close = true;
+                }
+            });
+        });
+
+    // Check for ESC key to close the span details window
+    ctx.input(|i| {
+        if i.key_pressed(Key::Escape) {
+            should_close = true;
+        }
+    });
+
+    !open || should_close
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1348,8 +1348,6 @@ impl App {
 
         // Only process spans once when the modal is first opened or if data hasn't been processed
         if !modal.spans_processed {
-            println!("Setting up analyze span modal using pre-loaded spans...");
-
             if !self.all_spans_for_analysis.is_empty() {
                 // Pass all spans to the modal for storage and analysis
                 modal.show_modal(ctx, &self.all_spans_for_analysis, max_width, max_height);
@@ -1515,8 +1513,6 @@ impl App {
 
         // Only process spans once when the modal is first opened or if data hasn't been processed
         if !self.analyze_dependency_modal.spans_processed {
-            println!("Setting up analyze dependency modal using pre-loaded spans...");
-
             if !self.all_spans_for_analysis.is_empty() {
                 // Pass all spans to the modal for storage and analysis
                 self.analyze_dependency_modal.show_modal(

--- a/src/main.rs
+++ b/src/main.rs
@@ -404,9 +404,8 @@ impl App {
         self.spans_to_display.clear();
         self.clicked_span = None;
         self.highlighted_spans.clear();
-        self.show_dependency_highlighting = false; // Revert
-        self.dependency_focus_target_node = None; // Add this
-                                                  // Reset modal processed flags so they pick up new data
+        self.show_dependency_highlighting = false;
+        self.dependency_focus_target_node = None;
         self.analyze_span_modal.reset_processed_flag();
         self.analyze_dependency_modal.reset_processed_flag();
 
@@ -838,7 +837,6 @@ impl App {
                     // Create a mapping from span_id to (node_name, y-position) for dependency arrows
                     let mut span_positions = HashMap::new();
 
-                    // First pass - arrange all spans and collect positions
                     for (node_name, (_node, spans)) in &node_spans {
                         let spans_in_range: Vec<Rc<Span>> = spans
                             .iter()
@@ -868,14 +866,15 @@ impl App {
                         );
                         let bbox = arrange_spans(&spans_in_range, true);
 
-                        // Collect positions of all spans for later dependency arrow drawing
-                        self.collect_span_positions(
-                            &spans_in_range,
-                            cur_height,
-                            span_height,
-                            node_name,
-                            &mut span_positions,
-                        );
+                        if self.show_dependency_highlighting && self.highlighted_spans.len() >= 2 {
+                            self.collect_span_positions(
+                                &spans_in_range,
+                                cur_height,
+                                span_height,
+                                node_name,
+                                &mut span_positions,
+                            );
+                        }
 
                         ui.style_mut().visuals.override_text_color = Some(Color32::BLACK);
                         self.draw_arranged_spans(&spans_in_range, ui, cur_height, span_height, 0);
@@ -904,7 +903,7 @@ impl App {
                         cur_height = next_height;
                     }
 
-                    // Second pass - draw dependency arrows if needed
+                    // Draw dependency arrows if needed
                     if self.show_dependency_highlighting && self.highlighted_spans.len() >= 2 {
                         let time_params = TimeToScreenParams {
                             selected_start_time: self.timeline.selected_start,
@@ -965,7 +964,6 @@ impl App {
         self.timeline_bar2_time += shift;
     }
 
-    // Add a new version that takes highlighted spans into account
     fn set_display_params_with_highlights(
         spans: &[Rc<Span>],
         highlighted_spans: &[Rc<Span>],

--- a/src/main.rs
+++ b/src/main.rs
@@ -352,26 +352,18 @@ impl App {
             let has_spans = !self.spans_to_display.is_empty();
             let analyze_button = ui.add_enabled(has_spans, Button::new("Analyze Span"));
             if analyze_button.clicked() {
-                self.analyze_span_modal.show = true;
-                self.analyze_span_modal.search_text = String::new();
-                self.analyze_span_modal
-                    .update_span_list(&self.spans_to_display);
+                self.analyze_span_modal.open(&self.spans_to_display);
             }
 
             // Analyze Dependency button, disabled if no spans are loaded
             let analyze_dep_button = ui.add_enabled(has_spans, Button::new("Analyze Dependency"));
             if analyze_dep_button.clicked() {
-                self.analyze_dependency_modal.show = true;
-                self.analyze_dependency_modal.source_search_text = String::new();
-                self.analyze_dependency_modal.target_search_text = String::new();
-                self.analyze_dependency_modal
-                    .update_span_list(&self.spans_to_display);
+                self.analyze_dependency_modal.open(&self.spans_to_display);
             }
 
             // Clear Highlights button, only enabled when there are highlighted spans
             let has_highlights =
                 self.show_dependency_highlighting && !self.highlighted_spans.is_empty();
-
             ui.with_layout(
                 egui::Layout::right_to_left(eframe::emath::Align::RIGHT),
                 |ui| {
@@ -390,7 +382,7 @@ impl App {
                         );
                         self.show_dependency_highlighting = false;
                         self.highlighted_spans.clear();
-                        self.dependency_focus_target_node = None; // Cleared here
+                        self.dependency_focus_target_node = None;
                     }
                 },
             );
@@ -1732,14 +1724,13 @@ impl App {
                                             });
                                         }
                                     }
-                                } // else { REMOVED: println! for Source span not found }
+                                }
                             }
-                        } // else { REMOVED: println! for Target span not found }
+                        }
                     }
-                    // REMOVED: println! for Finished drawing links
-                } // else { REMOVED: println! for No analysis result found for node }
-            } // else { REMOVED: println! for No dependency_focus_target_node set }
-        } // else { REMOVED: println! for No analysis result available in modal }
+                }
+            }
+        }
 
         if self.hovered_arrow_key != current_frame_hovered_key {
             self.hovered_arrow_key = current_frame_hovered_key;

--- a/src/main.rs
+++ b/src/main.rs
@@ -128,7 +128,6 @@ struct App {
 
     // Spans highlighting
     highlighted_spans: Vec<Rc<Span>>,
-    show_dependency_highlighting: bool,
     dependency_focus_target_node: Option<String>,
 
     // Dependency arrow interactivity
@@ -222,7 +221,6 @@ impl Default for App {
             analyze_span_modal: AnalyzeSpanModal::default(),
             analyze_dependency_modal: AnalyzeDependencyModal::new(),
             highlighted_spans: Vec::new(),
-            show_dependency_highlighting: false,
             dependency_focus_target_node: None,
             clicked_arrow_info: None,
             hovered_arrow_key: None,
@@ -364,8 +362,7 @@ impl App {
             }
 
             // Clear Highlights button, only enabled when there are highlighted spans
-            let has_highlights =
-                self.show_dependency_highlighting && !self.highlighted_spans.is_empty();
+            let has_highlights = !self.highlighted_spans.is_empty();
             ui.with_layout(
                 egui::Layout::right_to_left(eframe::emath::Align::RIGHT),
                 |ui| {
@@ -382,7 +379,6 @@ impl App {
                             "Clearing {} highlighted spans",
                             self.highlighted_spans.len()
                         );
-                        self.show_dependency_highlighting = false;
                         self.highlighted_spans.clear();
                         self.analyze_dependency_modal.clear_focus();
                         self.dependency_focus_target_node = None;
@@ -404,7 +400,6 @@ impl App {
         self.spans_to_display.clear();
         self.clicked_span = None;
         self.highlighted_spans.clear();
-        self.show_dependency_highlighting = false;
         self.dependency_focus_target_node = None;
         self.analyze_span_modal.reset_processed_flag();
         self.analyze_dependency_modal.reset_processed_flag();
@@ -866,7 +861,7 @@ impl App {
                         );
                         let bbox = arrange_spans(&spans_in_range, true);
 
-                        if self.show_dependency_highlighting && self.highlighted_spans.len() >= 2 {
+                        if !self.highlighted_spans.is_empty() {
                             self.collect_span_positions(
                                 &spans_in_range,
                                 cur_height,
@@ -904,7 +899,7 @@ impl App {
                     }
 
                     // Draw dependency arrows if needed
-                    if self.show_dependency_highlighting && self.highlighted_spans.len() >= 2 {
+                    if !self.highlighted_spans.is_empty() {
                         let time_params = TimeToScreenParams {
                             selected_start_time: self.timeline.selected_start,
                             selected_end_time: self.timeline.selected_end,
@@ -1050,7 +1045,7 @@ impl App {
         level: u64,
     ) {
         // Check if this span is highlighted
-        let is_highlighted = self.show_dependency_highlighting
+        let is_highlighted = !self.highlighted_spans.is_empty()
             && self // Revert condition
                 .highlighted_spans
                 .iter()
@@ -1425,8 +1420,6 @@ impl App {
             } else {
                 println!("No analysis result available!");
             }
-            // Enable highlighting
-            self.show_dependency_highlighting = true;
         }
 
         // Regular modal functionality

--- a/src/main.rs
+++ b/src/main.rs
@@ -1090,7 +1090,7 @@ impl App {
                 // Extract ALL spans from raw data for analysis
                 match everything_mode(&self.raw_data) {
                     Ok(all_spans) => {
-                        println!("Extracted {} total spans for analysis", all_spans.len());
+                        println!("Extracted {} parent spans for analysis", all_spans.len());
                         // Pass all spans to the modal for storage and analysis
                         modal.show_modal(ctx, &all_spans, max_width, max_height);
                         modal.spans_processed = true;

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
 use task_timer::TaskTimer;
 use types::{
     time_point_to_utc_string, value_to_text, DisplayLength, Event, HeightLevel, Node, Span,
-    TimePoint,
+    TimePoint, MILLISECONDS_PER_SECOND,
 };
 
 mod analyze_dependency;
@@ -1216,7 +1216,7 @@ impl App {
                 ui.separator();
                 ui.label(format!(
                     "{:.3} ms",
-                    (span.end_time - span.start_time) * 1000.0
+                    (span.end_time - span.start_time) * MILLISECONDS_PER_SECOND
                 ));
                 ui.label(format!(
                     "{} - {}",
@@ -1275,7 +1275,7 @@ impl App {
                 ui.label("");
                 ui.label(format!(
                     "{:.3} ms",
-                    (span.end_time - span.start_time) * 1000.0
+                    (span.end_time - span.start_time) * MILLISECONDS_PER_SECOND
                 ));
                 ui.label(format!(
                     "{} - {}",
@@ -1694,7 +1694,8 @@ impl App {
                                         time_params.selected_end_time,
                                     );
                                     let from_pos = Pos2::new(source_x_pos, source_y_pos);
-                                    let distance_ms = (t.start_time - s_source.end_time) * 1000.0;
+                                    let distance_ms = (t.start_time - s_source.end_time)
+                                        * MILLISECONDS_PER_SECOND;
 
                                     if distance_ms >= 0.0 {
                                         let arrow_key = ArrowKey {
@@ -1831,7 +1832,7 @@ impl App {
                         ui.end_row();
 
                         ui.strong("Link Duration:");
-                        ui.label(format!("{:.3} ms", info.duration * 1000.0));
+                        ui.label(format!("{:.3} ms", info.duration * MILLISECONDS_PER_SECOND));
                         ui.end_row();
                     });
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1340,9 +1340,7 @@ impl App {
     fn draw_analyze_span_modal(&mut self, ctx: &egui::Context, max_width: f32, max_height: f32) {
         if !self.analyze_span_modal.show {
             // Reset the processed flag when closing the modal
-            if self.analyze_span_modal.spans_processed {
-                self.analyze_span_modal.spans_processed = false;
-            }
+            self.analyze_span_modal.spans_processed = false;
             return;
         }
 
@@ -1353,10 +1351,6 @@ impl App {
             println!("Setting up analyze span modal using pre-loaded spans...");
 
             if !self.all_spans_for_analysis.is_empty() {
-                println!(
-                    "Using {} pre-loaded parent spans for analysis modal.",
-                    self.all_spans_for_analysis.len()
-                );
                 // Pass all spans to the modal for storage and analysis
                 modal.show_modal(ctx, &self.all_spans_for_analysis, max_width, max_height);
                 modal.spans_processed = true; // Mark as processed for this dataset
@@ -1386,7 +1380,6 @@ impl App {
         if !self.analyze_dependency_modal.show && self.analyze_dependency_modal.focus_node.is_some()
         {
             let focus_node_name = self.analyze_dependency_modal.focus_node.take().unwrap();
-            println!("Focus requested for node: {}", focus_node_name);
             self.dependency_focus_target_node = Some(focus_node_name.clone()); // Set here
 
             // Clear previous highlights
@@ -1436,8 +1429,6 @@ impl App {
                         "Looking for {} span IDs to highlight",
                         span_ids_to_find.len()
                     );
-                    println!("Spans to display count: {}", self.spans_to_display.len());
-
                     // Then search for all spans in the display tree
                     for id_pair in span_ids_to_find.iter() {
                         let mut candidates = Vec::new();
@@ -1453,12 +1444,6 @@ impl App {
                                     spans_to_highlight.push(candidate.clone());
                                 }
                             }
-                        } else {
-                            println!(
-                                "  No span found with ID: {} in node: {}",
-                                hex::encode(&id_pair.0),
-                                id_pair.1
-                            );
                         }
                     }
 
@@ -1480,7 +1465,6 @@ impl App {
 
                     // Adjust timeline to show these spans if needed
                     if !self.highlighted_spans.is_empty() {
-                        println!("Highlighting {} spans", self.highlighted_spans.len());
                         let mut min_time = f64::MAX;
                         let mut max_time = f64::MIN;
 
@@ -1534,10 +1518,6 @@ impl App {
             println!("Setting up analyze dependency modal using pre-loaded spans...");
 
             if !self.all_spans_for_analysis.is_empty() {
-                println!(
-                    "Using {} pre-loaded parent spans for dependency analysis modal.",
-                    self.all_spans_for_analysis.len()
-                );
                 // Pass all spans to the modal for storage and analysis
                 self.analyze_dependency_modal.show_modal(
                     ctx,
@@ -1683,8 +1663,6 @@ impl App {
             // Use the explicitly stored focused target node name
             if let Some(ref focused_target_node_name) = self.dependency_focus_target_node {
                 if let Some(node_result) = analysis.per_node_results.get(focused_target_node_name) {
-                    // All initial println! and drawn_links_count removed here
-
                     for link in node_result.links.iter() {
                         if link.source_spans.is_empty() {
                             continue;
@@ -2297,11 +2275,6 @@ fn find_spans_with_id(
         // Also check children
         if !span.children.borrow().is_empty() {
             find_spans_with_id(&span.children.borrow(), span_id, node_name, results);
-        }
-
-        // Also check all spans in the display_children (which may differ from children)
-        if !span.display_children.borrow().is_empty() {
-            find_spans_with_id(&span.display_children.borrow(), span_id, node_name, results);
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1265,9 +1265,7 @@ impl App {
         if !self.analyze_span_modal.show {
             return;
         }
-
         let modal = &mut self.analyze_span_modal;
-
         modal.show_modal(ctx, max_width, max_height);
     }
 
@@ -1277,12 +1275,9 @@ impl App {
         max_width: f32,
         max_height: f32,
     ) {
-        let mut error_message = None;
-
-        // Handle focus_node if modal just closed
+        // Handle focus_node if user closed the modal by selecting to highlight some spans
         if !self.analyze_dependency_modal.show && self.analyze_dependency_modal.focus_node.is_some()
         {
-            // Get focus_node_name by taking it from the modal and store it in App
             let focus_node_name = self.analyze_dependency_modal.focus_node.take().unwrap();
             self.dependency_focus_target_node = Some(focus_node_name.clone());
 
@@ -1334,11 +1329,6 @@ impl App {
                     // Assign the collected unique spans
                     self.highlighted_spans = spans_to_highlight;
 
-                    set_display_children_with_highlights(
-                        &self.spans_to_display,
-                        &self.highlighted_spans,
-                    );
-
                     // Adjust timeline to show these spans if needed
                     if !self.highlighted_spans.is_empty() {
                         let mut min_time = f64::MAX;
@@ -1379,33 +1369,11 @@ impl App {
             }
         }
 
-        // Regular modal functionality
         if !self.analyze_dependency_modal.show {
             return;
         }
-
         let modal = &mut self.analyze_dependency_modal;
-
-        // Only process spans once when the modal is first opened or if data hasn't been processed
-        if !modal.spans_processed {
-            if !self.all_spans_for_analysis.is_empty() {
-                // Pass all spans to the modal for storage and analysis
-                modal.show_modal(ctx, max_width, max_height);
-                modal.spans_processed = true;
-            } else {
-                error_message = Some(
-                    "No trace data (all_spans_for_analysis) available for dependency analysis. Load a file first.".to_string()
-                );
-                modal.show = false;
-            }
-        } else {
-            modal.show_modal(ctx, max_width, max_height);
-        }
-
-        // Handle any error message after the modal processing
-        if let Some(msg) = error_message {
-            println!("Error occurred: {}", msg); // Replaced with a simple println
-        }
+        modal.show_modal(ctx, max_width, max_height);
     }
 
     // Collect positions of all spans in a node, including children

--- a/src/types.rs
+++ b/src/types.rs
@@ -94,7 +94,11 @@ pub fn value_to_text(value_opt: &Option<Value>) -> String {
         Value::DoubleValue(d) => d.to_string(),
         Value::ArrayValue(a) => format!(
             "[{}]",
-            a.values.iter().map(|v| value_to_text(&v.value)).collect::<Vec<_>>().join(", ")
+            a.values
+                .iter()
+                .map(|v| value_to_text(&v.value))
+                .collect::<Vec<_>>()
+                .join(", ")
         ),
         Value::KvlistValue(kv) => format!(
             "{{{}}}",

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,6 +5,8 @@ use std::rc::Rc;
 
 use opentelemetry_proto::tonic::common::v1::any_value::Value;
 
+pub const MILLISECONDS_PER_SECOND: f64 = 1000.0;
+
 /// Seconds since epoch
 /// TODO: make nicer, f64 isn't great for this
 pub type TimePoint = f64;

--- a/src/types.rs
+++ b/src/types.rs
@@ -185,6 +185,7 @@ pub fn stringify_attributes(attributes: &BTreeMap<String, Option<Value>>) -> Str
     s
 }
 
+/// Identifies a node (by its name) or the entire set of nodes.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum NodeIdentifier {
     Node(String),

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,7 @@
 #![allow(unused)]
 use std::cell::{Cell, Ref, RefCell};
 use std::collections::BTreeMap;
+use std::fmt;
 use std::rc::Rc;
 
 use opentelemetry_proto::tonic::common::v1::any_value::Value;
@@ -182,4 +183,19 @@ pub fn stringify_attributes(attributes: &BTreeMap<String, Option<Value>>) -> Str
     }
     s.push('}');
     s
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum NodeIdentifier {
+    Node(String),
+    AllNodes,
+}
+
+impl fmt::Display for NodeIdentifier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            NodeIdentifier::Node(name) => write!(f, "{}", name),
+            NodeIdentifier::AllNodes => write!(f, "ALL NODES"),
+        }
+    }
 }


### PR DESCRIPTION
Alright, sorry about the huge PR! 
I'm re-opening it now that I've cleaned up the code to a decent level.

The changes are massive. There's a lot of overlap between `analyze_span` and `analyze_dependency` and it was easier to bundle together some of their UI widgets.

I tried to isolate stuff into separate files, or functions in `main.rs`. Maybe I could have moved some extra structs out of main, but I wasn't sure.

Unfortunately, some parts of the logic are bit complex. For instance all the configurations to decide how to form links or the way we detect mouse hovering on tilted arrows..


### Analyze a class of spans, per node, in the entire trace file
<img width="1090" alt="image" src="https://github.com/user-attachments/assets/1e00a016-05f9-45ed-94b1-43497cd492b0" />


### Analyze dependencies between classes of spans, per node, in the entire trace file; plus highlighting and arrow linking in the main view

<img width="1087" alt="image" src="https://github.com/user-attachments/assets/e812967f-7aab-4bda-9968-e2db0a2697b5" />
<img width="1279" alt="image" src="https://github.com/user-attachments/assets/578e5810-76f0-4ecc-8fff-51f6afc9a275" />


