### PR TITLE
experimental profiling instrumentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3356,6 +3356,7 @@ dependencies = [
  "chrono",
  "eframe",
  "hex",
+ "once_cell",
  "opentelemetry-proto",
  "rfd",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,11 @@ hex = "0.4.3"
 opentelemetry-proto = { version = "0.5.0", features = ["gen-tonic", "trace", "with-serde"] }
 rfd = "0.15.2"
 serde_json = "1.0.138"
+once_cell = "1.19.0"
+
+[features]
+default = []
+profiling = []
 
 [profile.dev.package."*"]
 opt-level = 3

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,8 @@ use types::{
 };
 
 mod modes;
+#[cfg(feature = "profiling")]
+mod profiling;
 mod structured_modes;
 mod task_timer;
 mod types;
@@ -219,6 +221,8 @@ impl eframe::App for App {
                 }
 
                 t.inspect(|t| t.stop());
+                #[cfg(feature = "profiling")]
+                profiling::GLOBAL_PROFILER.increment_frame_count();
             });
     }
 }
@@ -600,6 +604,8 @@ impl App {
     }
 
     fn draw_spans(&mut self, area: Rect, ui: &mut Ui) {
+        #[cfg(feature = "profiling")]
+        let _timing_guard = profiling::GLOBAL_PROFILER.start_timing("draw_spans");
         let mut node_spans: BTreeMap<String, (Rc<Node>, Vec<Rc<Span>>)> = BTreeMap::new();
         for span in &self.spans_to_display {
             node_spans
@@ -838,6 +844,8 @@ impl App {
         span_height: f32,
         level: u64,
     ) {
+        #[cfg(feature = "profiling")]
+        let _timing_guard = profiling::GLOBAL_PROFILER.start_timing("draw_arranged_spans");
         for span in spans {
             let next_start_height = start_height
                 + span.parent_height_offset.get() as f32 * (span_height + self.layout.span_margin);
@@ -1062,6 +1070,9 @@ struct SpanBoundingBox {
 
 /// Sets relative_display_pos for all spans and their children
 fn arrange_spans(input_spans: &[Rc<Span>], first_invocation: bool) -> SpanBoundingBox {
+    #[cfg(feature = "profiling")]
+    let _timing_guard = profiling::GLOBAL_PROFILER.start_timing("arrange_spans");
+
     if input_spans.is_empty() {
         return SpanBoundingBox {
             start: 0.0,

--- a/src/profiling.rs
+++ b/src/profiling.rs
@@ -1,0 +1,121 @@
+use once_cell::sync::Lazy;
+use std::collections::HashMap;
+use std::sync::{
+    atomic::{AtomicU32, Ordering},
+    Arc, Mutex,
+};
+use std::thread;
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Clone, Default)]
+struct FunctionTiming {
+    total_duration: Duration,
+    call_count: u32,
+}
+
+pub struct Profiler {
+    timings: Arc<Mutex<HashMap<String, FunctionTiming>>>,
+    frame_count: Arc<AtomicU32>,
+}
+
+pub static GLOBAL_PROFILER: Lazy<Profiler> = Lazy::new(Profiler::new);
+
+impl Profiler {
+    fn new() -> Self {
+        let timings = Arc::new(Mutex::new(HashMap::<String, FunctionTiming>::new()));
+        let timings_clone = Arc::clone(&timings);
+        let frame_count = Arc::new(AtomicU32::new(0));
+        let frame_count_clone = Arc::clone(&frame_count);
+        thread::spawn(move || {
+            let mut last_report_time = Instant::now();
+            loop {
+                thread::sleep(Duration::from_secs(5));
+
+                let interval_duration;
+                let current_frames_val;
+                let report_data: Vec<(String, FunctionTiming)>;
+
+                // Try to hold the lock for as short as possible
+                {
+                    let mut timings_guard = timings_clone.lock().unwrap();
+                    let now = Instant::now();
+
+                    current_frames_val = frame_count_clone.swap(0, Ordering::Relaxed);
+                    interval_duration = now.duration_since(last_report_time);
+
+                    report_data = timings_guard
+                        .iter()
+                        .map(|(name, timing)| (name.clone(), timing.clone()))
+                        .collect();
+
+                    // Reset timings for the next interval
+                    for (_, timing) in timings_guard.iter_mut() {
+                        timing.total_duration = Duration::ZERO;
+                        timing.call_count = 0;
+                    }
+                    last_report_time = now;
+                }
+
+                println!(
+                    "[PROFILE] Report for the last {:.2}s:",
+                    interval_duration.as_secs_f32()
+                );
+
+                let mut sorted_timings = report_data;
+                sorted_timings.sort_by_key(|(name, _)| name.clone());
+
+                for (name, timing) in sorted_timings {
+                    println!(
+                        "[PROFILE]  - {}: {:.3}ms ({} calls)",
+                        name,
+                        timing.total_duration.as_secs_f32() * 1000.0,
+                        timing.call_count
+                    );
+                }
+
+                let fps = if interval_duration.as_secs_f32() > 0.0 {
+                    current_frames_val as f32 / interval_duration.as_secs_f32()
+                } else {
+                    0.0
+                };
+                println!("[PROFILE]  - Average FPS: {:.2}", fps);
+                println!("[PROFILE] --- End of Report ---");
+            }
+        });
+
+        Self {
+            timings,
+            frame_count,
+        }
+    }
+
+    pub fn start_timing(&self, fn_name: &'static str) -> TimingGuard {
+        TimingGuard {
+            fn_name,
+            start_time: Some(Instant::now()),
+            timings_map: Arc::clone(&self.timings),
+        }
+    }
+
+    pub fn increment_frame_count(&self) {
+        self.frame_count.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+pub struct TimingGuard {
+    fn_name: &'static str,
+    start_time: Option<Instant>,
+    timings_map: Arc<Mutex<HashMap<String, FunctionTiming>>>,
+}
+
+impl Drop for TimingGuard {
+    fn drop(&mut self) {
+        if let Some(start_time) = self.start_time {
+            let duration = start_time.elapsed();
+            let mut timings = self.timings_map.lock().unwrap();
+            let entry = timings.entry(self.fn_name.to_string()).or_default();
+            entry.total_duration += duration;
+            entry.call_count += 1;
+        }
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -94,7 +94,11 @@ pub fn value_to_text(value_opt: &Option<Value>) -> String {
         Value::DoubleValue(d) => d.to_string(),
         Value::ArrayValue(a) => format!(
             "[{}]",
-            a.values.iter().map(|v| value_to_text(&v.value)).collect::<Vec<_>>().join(", ")
+            a.values
+                .iter()
+                .map(|v| value_to_text(&v.value))
+                .collect::<Vec<_>>()
+                .join(", ")
         ),
         Value::KvlistValue(kv) => format!(
             "{{{}}}",


### PR DESCRIPTION
I was thinking to add a profiling debug log, to check how much time is spent in some functions

Task timer is good for "one-off" routine, but it felt unwieldy when a function is called multiple times.


This `rough` profiler class is enabled by running `cargo run --release --features=profiling`

and it outputs in console:
```
[PROFILE] Report for the last 5.01s:
[PROFILE]  - arrange_spans: 136.458ms (146308 calls)
[PROFILE]  - draw_arranged_spans: 126.918ms (343104 calls)
[PROFILE]  - draw_spans: 651.299ms (494 calls)
[PROFILE]  - Average FPS: 98.70
[PROFILE] --- End of Report ---
```