### PR TITLE
Editable display modes and node filters in the UI

### DIFF
--- a/src/edit_modes.rs
+++ b/src/edit_modes.rs
@@ -232,7 +232,7 @@ impl EditDisplayModes {
 
         result
     }
-    
+
     fn draw_delete_confirmation(&mut self, ui: &mut Ui, _ctx: &egui::Context) {
         ui.label("Are you sure you want to delete this mode?");
         self.draw_short_separator(ui);
@@ -322,6 +322,14 @@ impl EditDisplayModes {
                         self.selected_span_rule_idx = self.current_mode.span_rules.len() - 1;
                     }
                 }
+            }
+            if ui.button("Clone rule").clicked()
+                && self.selected_span_rule_idx < self.current_mode.span_rules.len()
+            {
+                let mut new_rule = self.current_mode.span_rules[self.selected_span_rule_idx].clone();
+                new_rule.name = format!("{} Clone", new_rule.name);
+                self.current_mode.span_rules.push(new_rule);
+                self.selected_span_rule_idx = self.current_mode.span_rules.len() - 1;
             }
             if ui.button("Move up").clicked() && self.selected_span_rule_idx > 0 {
                 self.current_mode

--- a/src/edit_modes.rs
+++ b/src/edit_modes.rs
@@ -185,7 +185,9 @@ impl EditDisplayModes {
                         self.editing_or_adding_mode = AddingOrEditing::Editing;
                         self.state = EditDisplayModesState::EditingMode;
                     } else {
-                        self.not_editable_message = "This mode is not editable! Builtin modes that are provided in traviz cannot be changed from the UI. You can clone this mode to create your own custom one and then edit the custom mode".to_string();
+                        self.not_editable_message = 
+                        "This mode is not editable! Builtin modes that are provided in traviz cannot be changed from the UI. \
+                        You can clone this mode to create your own custom one and then edit the custom mode".to_string();
                         self.state = EditDisplayModesState::NotEditableError;
                     }
                 }

--- a/src/edit_modes.rs
+++ b/src/edit_modes.rs
@@ -94,31 +94,14 @@ impl EditDisplayModes {
     fn new_mode() -> StructuredMode {
         StructuredMode {
             name: "New Mode".to_string(),
-            span_rules: vec![SpanRule {
-                name: "Show apply_new_chunk".to_string(),
-                selector: SpanSelector {
-                    span_name_condition: MatchCondition {
-                        operator: MatchOperator::EqualTo,
-                        value: "apply_new_chunk".to_string(),
-                    },
-                    node_name_condition: MatchCondition::any(),
-                    attribute_conditions: Vec::new(),
-                },
-                decision: SpanDecision {
-                    visible: true,
-                    display_length: DisplayLength::Text,
-                    replace_name: String::new(),
-                    add_height_to_name: true,
-                    add_shard_id_to_name: true,
-                },
-            }],
+            span_rules: vec![Self::new_span_rule()],
             is_editable: true,
         }
     }
 
     fn new_span_rule() -> SpanRule {
         SpanRule {
-            name: "New Span Rule".to_string(),
+            name: "Rule 1".to_string(),
             selector: SpanSelector {
                 span_name_condition: MatchCondition {
                     operator: MatchOperator::EqualTo,
@@ -131,8 +114,8 @@ impl EditDisplayModes {
                 visible: true,
                 display_length: DisplayLength::Text,
                 replace_name: String::new(),
-                add_height_to_name: false,
-                add_shard_id_to_name: false,
+                add_height_to_name: true,
+                add_shard_id_to_name: true,
             },
         }
     }

--- a/src/edit_modes.rs
+++ b/src/edit_modes.rs
@@ -26,7 +26,6 @@ pub struct EditDisplayModes {
 enum EditDisplayModesState {
     Closed,
     Opened,
-    CloningMode,
     DeleteModeConfirmation,
     NotEditableError,
     EditingMode,
@@ -80,7 +79,6 @@ impl EditDisplayModes {
             match self.state {
                 EditDisplayModesState::Closed => unreachable!(),
                 EditDisplayModesState::Opened => result = self.draw_opened(ui, ctx),
-                EditDisplayModesState::CloningMode => self.draw_cloning_mode(ui, ctx),
                 EditDisplayModesState::DeleteModeConfirmation => {
                     self.draw_delete_confirmation(ui, ctx)
                 }
@@ -204,8 +202,8 @@ impl EditDisplayModes {
                 let mut new_mode = self.all_modes[self.selected_mode_idx].clone();
                 new_mode.name = format!("{} Clone", new_mode.name);
                 new_mode.is_editable = true;
-                self.state = EditDisplayModesState::CloningMode;
-                self.current_mode = new_mode;
+                self.all_modes.push(new_mode);
+                self.selected_mode_idx = self.all_modes.len() - 1;
             }
             if ui.button("Delete Mode").clicked() {
                 if let Some(mode) = self.all_modes.get(self.selected_mode_idx) {
@@ -234,27 +232,7 @@ impl EditDisplayModes {
 
         result
     }
-
-    fn draw_cloning_mode(&mut self, ui: &mut Ui, _ctx: &egui::Context) {
-        ui.label("Clone Mode");
-        self.draw_short_separator(ui);
-
-        ui.horizontal(|ui| {
-            ui.label("Mode Name:");
-            ui.text_edit_singleline(&mut self.current_mode.name);
-        });
-
-        self.draw_short_separator(ui);
-        if ui.button("Clone").clicked() {
-            self.all_modes.push(self.current_mode.clone());
-            self.selected_mode_idx = self.all_modes.len() - 1;
-            self.state = EditDisplayModesState::Opened;
-        }
-        if ui.button("Cancel").clicked() {
-            self.state = EditDisplayModesState::Opened;
-        }
-    }
-
+    
     fn draw_delete_confirmation(&mut self, ui: &mut Ui, _ctx: &egui::Context) {
         ui.label("Are you sure you want to delete this mode?");
         self.draw_short_separator(ui);

--- a/src/edit_modes.rs
+++ b/src/edit_modes.rs
@@ -63,7 +63,6 @@ impl EditDisplayModes {
 
     pub fn draw(
         &mut self,
-        _ui: &mut Ui,
         ctx: &egui::Context,
         max_width: f32,
         max_height: f32,

--- a/src/edit_modes.rs
+++ b/src/edit_modes.rs
@@ -331,15 +331,15 @@ impl EditDisplayModes {
             if ui.button("Move up").clicked() && self.selected_span_rule_idx > 0 {
                 self.current_mode
                     .span_rules
-                    .swap(self.selected_mode_idx, self.selected_mode_idx - 1);
+                    .swap(self.selected_span_rule_idx, self.selected_span_rule_idx - 1);
                 self.selected_span_rule_idx -= 1;
             }
             if ui.button("Move down").clicked()
-                && self.selected_span_rule_idx < self.current_mode.span_rules.len() - 1
+                && self.selected_span_rule_idx + 1 < self.current_mode.span_rules.len()
             {
                 self.current_mode
                     .span_rules
-                    .swap(self.selected_mode_idx, self.selected_mode_idx + 1);
+                    .swap(self.selected_span_rule_idx, self.selected_span_rule_idx + 1);
                 self.selected_span_rule_idx += 1;
             }
         });

--- a/src/edit_modes.rs
+++ b/src/edit_modes.rs
@@ -1,0 +1,517 @@
+use eframe::egui::{self, Button, ComboBox, Modal, ScrollArea, Ui, Widget};
+
+use crate::structured_modes::{
+    MatchCondition, MatchOperator, SpanDecision, SpanRule, SpanSelector, StructuredMode,
+};
+use crate::types::DisplayLength;
+
+pub const HIGHLIGHT_COLOR: egui::Color32 = egui::Color32::from_rgb(51, 102, 153);
+
+pub struct EditDisplayModes {
+    state: EditDisplayModesState,
+    editing_or_adding_mode: AddingOrEditing,
+    editing_or_adding_rule: AddingOrEditing,
+
+    all_modes: Vec<StructuredMode>,
+    selected_mode_idx: usize,
+    current_mode: StructuredMode,
+    selected_span_rule_idx: usize,
+    current_span_rule: SpanRule,
+    max_width: f32,
+    max_height: f32,
+    not_editable_message: String,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum EditDisplayModesState {
+    Closed,
+    Opened,
+    CloningMode,
+    DeleteModeConfirmation,
+    NotEditableError,
+    EditingMode,
+    EditingSpanRule,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AddingOrEditing {
+    Adding,
+    Editing,
+}
+
+impl EditDisplayModes {
+    pub fn new() -> Self {
+        EditDisplayModes {
+            state: EditDisplayModesState::Closed,
+            editing_or_adding_mode: AddingOrEditing::Adding,
+            editing_or_adding_rule: AddingOrEditing::Adding,
+            all_modes: Vec::new(),
+            selected_mode_idx: 0,
+            current_mode: Self::new_mode(),
+            selected_span_rule_idx: 0,
+            current_span_rule: Self::new_span_rule(),
+            max_width: 800.0,
+            max_height: 600.0,
+            not_editable_message: String::new(),
+        }
+    }
+
+    pub fn open(&mut self, modes: Vec<StructuredMode>) {
+        self.all_modes = modes;
+        self.state = EditDisplayModesState::Opened;
+    }
+
+    pub fn draw(
+        &mut self,
+        _ui: &mut Ui,
+        ctx: &egui::Context,
+        max_width: f32,
+        max_height: f32,
+    ) -> Option<Vec<StructuredMode>> {
+        if self.state == EditDisplayModesState::Closed {
+            return None;
+        }
+
+        self.max_width = max_width;
+        self.max_height = max_height;
+        let mut result = None;
+        Modal::new("edit display modes".into()).show(ctx, |ui| {
+            ui.set_max_width(max_width);
+            ui.set_max_height(max_height);
+            match self.state {
+                EditDisplayModesState::Closed => unreachable!(),
+                EditDisplayModesState::Opened => result = self.draw_opened(ui, ctx),
+                EditDisplayModesState::CloningMode => self.draw_cloning_mode(ui, ctx),
+                EditDisplayModesState::DeleteModeConfirmation => {
+                    self.draw_delete_confirmation(ui, ctx)
+                }
+                EditDisplayModesState::NotEditableError => self.draw_not_editable_error(ui, ctx),
+                EditDisplayModesState::EditingMode => self.draw_editing_mode(ui, ctx),
+                EditDisplayModesState::EditingSpanRule => self.draw_editing_span_rule(ui, ctx),
+            }
+        });
+
+        result
+    }
+
+    fn new_mode() -> StructuredMode {
+        StructuredMode {
+            name: "New Mode".to_string(),
+            span_rules: vec![SpanRule {
+                name: "Show apply_new_chunk".to_string(),
+                selector: SpanSelector {
+                    span_name_condition: MatchCondition {
+                        operator: MatchOperator::EqualTo,
+                        value: "apply_new_chunk".to_string(),
+                    },
+                    node_name_condition: MatchCondition::any(),
+                    attribute_conditions: Vec::new(),
+                },
+                decision: SpanDecision {
+                    visible: true,
+                    display_length: DisplayLength::Text,
+                    replace_name: String::new(),
+                    add_height_to_name: true,
+                    add_shard_id_to_name: true,
+                },
+            }],
+            is_editable: true,
+        }
+    }
+
+    fn new_span_rule() -> SpanRule {
+        SpanRule {
+            name: "New Span Rule".to_string(),
+            selector: SpanSelector {
+                span_name_condition: MatchCondition {
+                    operator: MatchOperator::EqualTo,
+                    value: "MySpan".to_string(),
+                },
+                node_name_condition: MatchCondition::any(),
+                attribute_conditions: Vec::new(),
+            },
+            decision: SpanDecision {
+                visible: true,
+                display_length: DisplayLength::Text,
+                replace_name: String::new(),
+                add_height_to_name: false,
+                add_shard_id_to_name: false,
+            },
+        }
+    }
+
+    fn draw_short_separator(&self, ui: &mut Ui) {
+        ui.set_max_width(10.0);
+        ui.separator();
+        ui.set_max_width(self.max_width);
+    }
+
+    fn draw_opened(&mut self, ui: &mut Ui, _ctx: &egui::Context) -> Option<Vec<StructuredMode>> {
+        ui.label("Edit Display Modes");
+
+        self.draw_short_separator(ui);
+
+        ui.label("Modes");
+        ScrollArea::vertical()
+            .id_salt("display modes")
+            .show(ui, |ui| {
+                for (index, mode) in self.all_modes.iter().enumerate() {
+                    let button = if self.selected_mode_idx == index {
+                        Button::new(mode.name.clone()).fill(HIGHLIGHT_COLOR)
+                    } else {
+                        Button::new(mode.name.clone())
+                    };
+                    if button.ui(ui).clicked() {
+                        self.selected_mode_idx = index;
+                    }
+                }
+            });
+
+        self.draw_short_separator(ui);
+
+        ui.horizontal(|ui| {
+            if ui.button("New Mode").clicked() {
+                let new_mode = Self::new_mode();
+                self.current_mode = new_mode.clone();
+                self.selected_span_rule_idx = 0;
+                self.editing_or_adding_mode = AddingOrEditing::Adding;
+                self.state = EditDisplayModesState::EditingMode;
+            }
+            if ui.button("Edit Mode").clicked() {
+                if let Some(mode) = self.all_modes.get(self.selected_mode_idx) {
+                    if mode.is_editable {
+                        self.current_mode = mode.clone();
+                        self.selected_span_rule_idx = 0;
+                        self.editing_or_adding_mode = AddingOrEditing::Editing;
+                        self.state = EditDisplayModesState::EditingMode;
+                    } else {
+                        self.not_editable_message = "This mode is not editable! Builtin modes that are provided in traviz cannot be changed from the UI. You can clone this mode to create your own custom one and then edit the custom mode".to_string();
+                        self.state = EditDisplayModesState::NotEditableError;
+                    }
+                }
+            }
+            if ui.button("Clone Mode").clicked() {
+                let mut new_mode = self.all_modes[self.selected_mode_idx].clone();
+                new_mode.name = format!("{} Clone", new_mode.name);
+                new_mode.is_editable = true;
+                self.state = EditDisplayModesState::CloningMode;
+                self.current_mode = new_mode;
+            }
+            if ui.button("Delete Mode").clicked() {
+                if let Some(mode) = self.all_modes.get(self.selected_mode_idx) {
+                    if mode.is_editable {
+                        self.state = EditDisplayModesState::DeleteModeConfirmation;
+                    } else {
+                        self.not_editable_message = "Builtin modes can not be deleted".to_string();
+                        self.state = EditDisplayModesState::NotEditableError;
+                    }
+                }
+            }
+        });
+
+        let mut result = None;
+
+        self.draw_short_separator(ui);
+        ui.horizontal(|ui| {
+            if ui.button("Save").clicked() {
+                self.state = EditDisplayModesState::Closed;
+                result = Some(std::mem::take(&mut self.all_modes));
+            }
+            if ui.button("Cancel").clicked() {
+                self.state = EditDisplayModesState::Closed;
+            }
+        });
+
+        result
+    }
+
+    fn draw_cloning_mode(&mut self, ui: &mut Ui, _ctx: &egui::Context) {
+        ui.label("Clone Mode");
+        self.draw_short_separator(ui);
+
+        ui.horizontal(|ui| {
+            ui.label("Mode Name:");
+            ui.text_edit_singleline(&mut self.current_mode.name);
+        });
+
+        self.draw_short_separator(ui);
+        if ui.button("Clone").clicked() {
+            self.all_modes.push(self.current_mode.clone());
+            self.selected_mode_idx = self.all_modes.len() - 1;
+            self.state = EditDisplayModesState::Opened;
+        }
+        if ui.button("Cancel").clicked() {
+            self.state = EditDisplayModesState::Opened;
+        }
+    }
+
+    fn draw_delete_confirmation(&mut self, ui: &mut Ui, _ctx: &egui::Context) {
+        ui.label("Are you sure you want to delete this mode?");
+        self.draw_short_separator(ui);
+
+        if let Some(mode) = self.all_modes.get(self.selected_mode_idx) {
+            ui.label(format!("Mode Name: {}", mode.name));
+        }
+
+        self.draw_short_separator(ui);
+        if ui.button("Yes, Delete").clicked() {
+            self.all_modes.remove(self.selected_mode_idx);
+            self.selected_mode_idx = 0;
+            self.state = EditDisplayModesState::Opened;
+        }
+        if ui.button("No, Cancel").clicked() {
+            self.state = EditDisplayModesState::Opened;
+        }
+    }
+
+    fn draw_not_editable_error(&mut self, ui: &mut Ui, _ctx: &egui::Context) {
+        ui.label(&self.not_editable_message);
+        self.draw_short_separator(ui);
+        if ui.button("Ok").clicked() {
+            self.state = EditDisplayModesState::Opened;
+        }
+    }
+
+    fn draw_editing_mode(&mut self, ui: &mut Ui, _ctx: &egui::Context) {
+        ui.label("Editing Mode");
+        self.draw_short_separator(ui);
+        ui.horizontal(|ui| {
+            ui.label("Mode Name:");
+            ui.text_edit_singleline(&mut self.current_mode.name);
+        });
+        ui.horizontal(|ui| {
+            ui.vertical(|ui| {
+                ui.label("Span Rules");
+                ScrollArea::vertical().id_salt("span rules").show(ui, |ui| {
+                    for (index, rule) in self.current_mode.span_rules.iter().enumerate() {
+                        let button = if self.selected_span_rule_idx == index {
+                            Button::new(rule.name.to_string()).fill(HIGHLIGHT_COLOR)
+                        } else {
+                            Button::new(rule.name.to_string())
+                        };
+                        if button.ui(ui).clicked() {
+                            self.selected_span_rule_idx = index;
+                        }
+                    }
+                });
+            });
+        });
+        self.draw_short_separator(ui);
+        ui.horizontal(|ui| {
+            if ui.button("New Span Rule").clicked() {
+                self.current_span_rule = Self::new_span_rule();
+                self.state = EditDisplayModesState::EditingSpanRule;
+                self.editing_or_adding_rule = AddingOrEditing::Adding;
+            };
+            if ui.button("Edit").clicked() {
+                if let Some(span_rule) = self
+                    .current_mode
+                    .span_rules
+                    .get(self.selected_span_rule_idx)
+                {
+                    self.current_span_rule = span_rule.clone();
+                    self.state = EditDisplayModesState::EditingSpanRule;
+                    self.editing_or_adding_rule = AddingOrEditing::Editing;
+                }
+            }
+            if ui.button("Delete").clicked()
+                && self.selected_span_rule_idx < self.current_mode.span_rules.len()
+            {
+                self.current_mode
+                    .span_rules
+                    .remove(self.selected_span_rule_idx);
+                if self.selected_span_rule_idx >= self.current_mode.span_rules.len() {
+                    if self.current_mode.span_rules.is_empty() {
+                        self.selected_span_rule_idx = 0;
+                    } else {
+                        self.selected_span_rule_idx = self.current_mode.span_rules.len() - 1;
+                    }
+                }
+            }
+            if ui.button("Move up").clicked() && self.selected_span_rule_idx > 0 {
+                self.current_mode
+                    .span_rules
+                    .swap(self.selected_mode_idx, self.selected_mode_idx - 1);
+                self.selected_span_rule_idx -= 1;
+            }
+            if ui.button("Move down").clicked()
+                && self.selected_span_rule_idx < self.current_mode.span_rules.len() - 1
+            {
+                self.current_mode
+                    .span_rules
+                    .swap(self.selected_mode_idx, self.selected_mode_idx + 1);
+                self.selected_span_rule_idx += 1;
+            }
+        });
+        self.draw_short_separator(ui);
+        ui.horizontal(|ui| {
+            if ui.button("Ok").clicked() {
+                match self.editing_or_adding_mode {
+                    AddingOrEditing::Adding => {
+                        self.all_modes.push(self.current_mode.clone());
+                        self.selected_mode_idx = self.all_modes.len() - 1;
+                        self.state = EditDisplayModesState::Opened;
+                    }
+                    AddingOrEditing::Editing => {
+                        *self.all_modes.get_mut(self.selected_mode_idx).unwrap() =
+                            self.current_mode.clone();
+                        self.state = EditDisplayModesState::Opened;
+                    }
+                }
+            }
+            if ui.button("Cancel").clicked() {
+                self.state = EditDisplayModesState::Opened;
+            };
+        });
+    }
+
+    fn draw_editing_span_rule(&mut self, ui: &mut Ui, _ctx: &egui::Context) {
+        ui.label("Editing Span Rule");
+        self.draw_short_separator(ui);
+        ui.horizontal(|ui| {
+            ui.label("Rule Name:");
+            ui.text_edit_singleline(&mut self.current_span_rule.name);
+        });
+        self.draw_short_separator(ui);
+        ui.label("Span name condition");
+        Self::draw_edit_match_condition(
+            ui,
+            &mut self.current_span_rule.selector.span_name_condition,
+            "span name condition",
+        );
+        self.draw_short_separator(ui);
+        ui.label("Node name condition");
+        Self::draw_edit_match_condition(
+            ui,
+            &mut self.current_span_rule.selector.node_name_condition,
+            "node name condition",
+        );
+        self.draw_short_separator(ui);
+        ui.label("Attribute Conditions");
+        let mut attribute_condition_to_remove = None;
+        for (i, attr_condition) in &mut self
+            .current_span_rule
+            .selector
+            .attribute_conditions
+            .iter_mut()
+            .enumerate()
+        {
+            ui.horizontal(|ui| {
+                ui.label("Attribute Name:");
+                ui.text_edit_singleline(&mut attr_condition.0);
+                Self::draw_edit_match_condition(
+                    ui,
+                    &mut attr_condition.1,
+                    format!("attribute condition {}", i).as_str(),
+                );
+                if ui.button("Remove").clicked() {
+                    attribute_condition_to_remove = Some(i);
+                }
+            });
+        }
+        if let Some(idx) = attribute_condition_to_remove {
+            self.current_span_rule
+                .selector
+                .attribute_conditions
+                .remove(idx);
+        }
+        if ui.button("New Attribute Condition").clicked() {
+            self.current_span_rule.selector.attribute_conditions.push((
+                "attr".to_string(),
+                MatchCondition {
+                    operator: MatchOperator::EqualTo,
+                    value: "val".to_string(),
+                },
+            ));
+        }
+        self.draw_short_separator(ui);
+        ui.label("Decision");
+        ui.checkbox(&mut self.current_span_rule.decision.visible, "Visible");
+        ui.horizontal(|ui| {
+            ui.label("Display length:");
+            ComboBox::new("display length", "")
+                .selected_text(format!(
+                    "{:?}",
+                    self.current_span_rule.decision.display_length
+                ))
+                .show_ui(ui, |ui| {
+                    ui.selectable_value(
+                        &mut self.current_span_rule.decision.display_length,
+                        DisplayLength::Text,
+                        "Text",
+                    );
+                    ui.selectable_value(
+                        &mut self.current_span_rule.decision.display_length,
+                        DisplayLength::Time,
+                        "Time",
+                    );
+                });
+        });
+        ui.horizontal(|ui| {
+            ui.label("Replace span name with:");
+            ui.text_edit_singleline(&mut self.current_span_rule.decision.replace_name);
+        });
+        ui.checkbox(
+            &mut self.current_span_rule.decision.add_height_to_name,
+            "Add Height to Name",
+        );
+        ui.checkbox(
+            &mut self.current_span_rule.decision.add_shard_id_to_name,
+            "Add Shard ID to Name",
+        );
+        self.draw_short_separator(ui);
+
+        ui.horizontal(|ui| {
+            if ui.button("Ok").clicked() {
+                match self.editing_or_adding_rule {
+                    AddingOrEditing::Adding => {
+                        self.current_mode
+                            .span_rules
+                            .push(self.current_span_rule.clone());
+                        self.selected_span_rule_idx = self.current_mode.span_rules.len() - 1;
+                        self.state = EditDisplayModesState::EditingMode;
+                    }
+                    AddingOrEditing::Editing => {
+                        self.current_mode.span_rules[self.selected_span_rule_idx] =
+                            self.current_span_rule.clone();
+                        self.state = EditDisplayModesState::EditingMode;
+                    }
+                }
+            }
+            if ui.button("Cancel").clicked() {
+                self.state = EditDisplayModesState::EditingMode;
+            }
+        });
+    }
+
+    pub fn draw_edit_match_condition(ui: &mut Ui, condition: &mut MatchCondition, id_salt: &str) {
+        ComboBox::new(id_salt, "")
+            .selected_text(format!("{:?}", condition.operator))
+            .show_ui(ui, |ui| {
+                ui.selectable_value(&mut condition.operator, MatchOperator::Any, "Any");
+                ui.selectable_value(&mut condition.operator, MatchOperator::None, "None");
+                ui.selectable_value(&mut condition.operator, MatchOperator::EqualTo, "Equal To");
+                ui.selectable_value(
+                    &mut condition.operator,
+                    MatchOperator::NotEqualTo,
+                    "Not Equal To",
+                );
+                ui.selectable_value(&mut condition.operator, MatchOperator::Contains, "Contains");
+            });
+        match condition.operator {
+            MatchOperator::Any | MatchOperator::None => {}
+            MatchOperator::EqualTo | MatchOperator::NotEqualTo | MatchOperator::Contains => {
+                ui.horizontal(|ui| {
+                    ui.label("Value:");
+                    ui.text_edit_singleline(&mut condition.value);
+                });
+            }
+        }
+    }
+}
+
+impl Default for EditDisplayModes {
+    fn default() -> Self {
+        EditDisplayModes::new()
+    }
+}

--- a/src/edit_modes.rs
+++ b/src/edit_modes.rs
@@ -429,7 +429,25 @@ impl EditDisplayModes {
         }
         self.draw_short_separator(ui);
         ui.label("Decision");
-        ui.checkbox(&mut self.current_span_rule.decision.visible, "Visible");
+        ui.horizontal(|ui| {
+            ui.label("Visibility:");
+            ComboBox::new("span visible or hidden", "").selected_text(if self.current_span_rule.decision.visible {
+                "Show"
+            } else {
+                "Hide"
+            }).show_ui(ui, |ui| {
+                ui.selectable_value(
+                    &mut self.current_span_rule.decision.visible,
+                    true,
+                    "Show",
+                );
+                ui.selectable_value(
+                    &mut self.current_span_rule.decision.visible,
+                    false,
+                    "Hide",
+                );
+            });
+        });
         ui.horizontal(|ui| {
             ui.label("Display length:");
             ComboBox::new("display length", "")

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,7 +160,7 @@ impl Default for App {
             include_children_events: true,
             display_modes: structured_modes::get_all_structured_modes(),
             current_display_mode_index: 0,
-            node_filters: vec![NodeFilter::show_all()],
+            node_filters: vec![NodeFilter::show_all(), NodeFilter::show_none()],
             current_node_filter_index: 0,
             search: Search::default(),
             edit_display_modes: EditDisplayModes::new(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -219,12 +219,10 @@ impl eframe::App for App {
 
                 self.draw_clicked_span(ctx, window_width - 100.0, window_height - 100.0);
 
-                if let Some(new_display_modes) = self.edit_display_modes.draw(
-                    ui,
-                    ctx,
-                    window_width - 100.0,
-                    window_height - 100.0,
-                ) {
+                if let Some(new_display_modes) =
+                    self.edit_display_modes
+                        .draw(ctx, window_width - 100.0, window_height - 100.0)
+                {
                     self.display_modes = new_display_modes;
                     if self.current_display_mode_index >= self.display_modes.len() {
                         self.current_display_mode_index = 0;
@@ -234,12 +232,10 @@ impl eframe::App for App {
                     }
                 }
 
-                if let Some(new_node_filters) = self.edit_node_filters.draw(
-                    ui,
-                    ctx,
-                    window_width - 100.0,
-                    window_height - 100.0,
-                ) {
+                if let Some(new_node_filters) =
+                    self.edit_node_filters
+                        .draw(ctx, window_width - 100.0, window_height - 100.0)
+                {
                     self.node_filters = new_node_filters;
                     if self.current_node_filter_index >= self.node_filters.len() {
                         self.current_node_filter_index = 0;

--- a/src/modes.rs
+++ b/src/modes.rs
@@ -17,14 +17,17 @@ use crate::types::{
     SpanDisplayConfig,
 };
 
+#[allow(unused)]
 pub type DisplayModeTransform = Box<dyn Fn(&[ExportTraceServiceRequest]) -> Result<Vec<Rc<Span>>>>;
 
+#[allow(unused)]
 pub struct DisplayMode {
     pub name: String,
     /// Function which takes raw data and outputs spans that should be displayed.
     pub transformation: DisplayModeTransform,
 }
 
+#[allow(unused)]
 /// Get all of the built-in display modes.
 pub fn get_all_modes() -> Vec<DisplayMode> {
     // Include all structured modes in the display modes.
@@ -82,8 +85,8 @@ fn structured_mode_transformation_rek(
         modified_span.dont_collapse_this_span.set(true);
         modified_span.collapse_children.set(true);
     }
-    if decision.replace_name.is_some() {
-        modified_span.name = decision.replace_name.unwrap();
+    if !decision.replace_name.is_empty() {
+        modified_span.name = decision.replace_name;
     }
     if decision.add_height_to_name {
         add_height_to_name(&mut modified_span);

--- a/src/node_filter.rs
+++ b/src/node_filter.rs
@@ -410,10 +410,10 @@ impl EditNodeFilters {
 
     fn new_rule() -> NodeRule {
         NodeRule {
-            name: "Show my_node".to_string(),
+            name: "Rule 1".to_string(),
             condition: MatchCondition {
                 operator: MatchOperator::EqualTo,
-                value: "my_node".to_string(),
+                value: "something".to_string(),
             },
             visible: true,
         }

--- a/src/node_filter.rs
+++ b/src/node_filter.rs
@@ -149,13 +149,13 @@ impl EditNodeFilters {
                 if let Some(filter) = self.filters.get(self.selected_filter_idx) {
                     if filter.is_editable {
                         self.current_filter = filter.clone();
-                    self.selected_rule_idx = 0;
-                    self.editing_or_adding_filter = AddingOrEditing::Editing;
-                    self.state = EditNodeFiltersState::EditingFilter;
+                        self.selected_rule_idx = 0;
+                        self.editing_or_adding_filter = AddingOrEditing::Editing;
+                        self.state = EditNodeFiltersState::EditingFilter;
                     } else {
                         self.not_editable_message = "This filter is not editable! Builtin filters that are provided in traviz cannot be changed from the UI. You can clone this filter to create your own custom one and then edit the custom filter".to_string();
+                        self.state = EditNodeFiltersState::NotEditableError;
                     }
-                    
                 }
             }
             if ui.button("Clone Filter").clicked() {
@@ -286,20 +286,20 @@ impl EditNodeFilters {
                 self.current_filter.rules.remove(self.selected_rule_idx);
                 if self.selected_rule_idx >= self.current_filter.rules.len() {
                     if self.current_filter.rules.is_empty() {
-                        self.selected_filter_idx = 0;
+                        self.selected_rule_idx = 0;
                     } else {
-                        self.selected_filter_idx = self.current_filter.rules.len() - 1;
+                        self.selected_rule_idx = self.current_filter.rules.len() - 1;
                     }
                 }
             }
             if ui.button("Move up").clicked() && self.selected_rule_idx > 0 {
                 self.current_filter
                     .rules
-                    .swap(self.selected_filter_idx, self.selected_filter_idx - 1);
-                self.selected_filter_idx -= 1;
+                    .swap(self.selected_rule_idx, self.selected_rule_idx - 1);
+                self.selected_rule_idx -= 1;
             }
             if ui.button("Move down").clicked()
-                && self.selected_rule_idx < self.current_filter.rules.len() - 1
+                && self.selected_rule_idx + 1 < self.current_filter.rules.len()
             {
                 self.current_filter
                     .rules

--- a/src/node_filter.rs
+++ b/src/node_filter.rs
@@ -72,7 +72,6 @@ pub struct EditNodeFilters {
 pub enum EditNodeFiltersState {
     Closed,
     Open,
-    CloningFilter,
     DeleteFilterConfirmation,
     NotEditableError,
     EditingFilter,
@@ -120,7 +119,6 @@ impl EditNodeFilters {
             match self.state {
                 EditNodeFiltersState::Closed => unreachable!(),
                 EditNodeFiltersState::Open => result = self.draw_open(ui, ctx),
-                EditNodeFiltersState::CloningFilter => self.draw_cloning_filter(ui, ctx),
                 EditNodeFiltersState::DeleteFilterConfirmation => {
                     self.draw_delete_confirmation(ui, ctx)
                 }
@@ -189,8 +187,8 @@ impl EditNodeFilters {
                 let mut new_filter = self.filters[self.selected_filter_idx].clone();
                 new_filter.name = format!("{} Clone", new_filter.name);
                 new_filter.is_editable = true;
-                self.state = EditNodeFiltersState::CloningFilter;
-                self.current_filter = new_filter;
+                self.filters.push(new_filter);
+                self.selected_filter_idx = self.filters.len() - 1;
             }
             if ui.button("Delete Filter").clicked() {
                 if let Some(filter) = self.filters.get(self.selected_filter_idx) {
@@ -218,26 +216,6 @@ impl EditNodeFilters {
         });
 
         result
-    }
-
-    fn draw_cloning_filter(&mut self, ui: &mut Ui, _ctx: &egui::Context) {
-        ui.label("Clone Filter");
-        self.draw_short_separator(ui);
-
-        ui.horizontal(|ui| {
-            ui.label("Filter Name:");
-            ui.text_edit_singleline(&mut self.current_filter.name);
-        });
-
-        self.draw_short_separator(ui);
-        if ui.button("Clone").clicked() {
-            self.filters.push(self.current_filter.clone());
-            self.selected_filter_idx = self.filters.len() - 1;
-            self.state = EditNodeFiltersState::Open;
-        }
-        if ui.button("Cancel").clicked() {
-            self.state = EditNodeFiltersState::Open;
-        }
     }
 
     fn draw_delete_confirmation(&mut self, ui: &mut Ui, _ctx: &egui::Context) {

--- a/src/node_filter.rs
+++ b/src/node_filter.rs
@@ -153,7 +153,9 @@ impl EditNodeFilters {
                         self.editing_or_adding_filter = AddingOrEditing::Editing;
                         self.state = EditNodeFiltersState::EditingFilter;
                     } else {
-                        self.not_editable_message = "This filter is not editable! Builtin filters that are provided in traviz cannot be changed from the UI. You can clone this filter to create your own custom one and then edit the custom filter".to_string();
+                        self.not_editable_message =
+                        "This filter is not editable! Builtin filters that are provided in traviz cannot be changed from the UI. \
+                        You can clone this filter to create your own custom one and then edit the custom filter".to_string();
                         self.state = EditNodeFiltersState::NotEditableError;
                     }
                 }

--- a/src/node_filter.rs
+++ b/src/node_filter.rs
@@ -1,4 +1,4 @@
-use eframe::egui::{self, Button, Modal, ScrollArea, Ui, Vec2, Widget};
+use eframe::egui::{self, Button, ComboBox, Modal, ScrollArea, Ui, Vec2, Widget};
 
 use crate::edit_modes::{AddingOrEditing, EditDisplayModes, HIGHLIGHT_COLOR};
 use crate::structured_modes::{MatchCondition, MatchOperator};
@@ -366,7 +366,17 @@ impl EditNodeFilters {
         self.draw_short_separator(ui);
         ui.label("Decision");
         ui.horizontal(|ui| {
-            ui.checkbox(&mut self.current_rule.visible, "Visible");
+            ui.label("Visibility:");
+            ComboBox::new("node spans visible or hidden", "")
+                .selected_text(if self.current_rule.visible {
+                    "Show"
+                } else {
+                    "Hide"
+                })
+                .show_ui(ui, |ui| {
+                    ui.selectable_value(&mut self.current_rule.visible, true, "Show");
+                    ui.selectable_value(&mut self.current_rule.visible, false, "Hide");
+                });
         });
         self.draw_short_separator(ui);
         ui.horizontal(|ui| {

--- a/src/node_filter.rs
+++ b/src/node_filter.rs
@@ -304,6 +304,14 @@ impl EditNodeFilters {
                     }
                 }
             }
+            if ui.button("Clone rule").clicked()
+                && self.selected_rule_idx < self.current_filter.rules.len()
+            {
+                let mut new_rule = self.current_filter.rules[self.selected_rule_idx].clone();
+                new_rule.name = format!("{} Clone", new_rule.name);
+                self.current_filter.rules.push(new_rule);
+                self.selected_rule_idx = self.current_filter.rules.len() - 1;
+            }
             if ui.button("Move up").clicked() && self.selected_rule_idx > 0 {
                 self.current_filter
                     .rules

--- a/src/node_filter.rs
+++ b/src/node_filter.rs
@@ -1,0 +1,397 @@
+use eframe::egui::{self, Button, Modal, ScrollArea, Ui, Widget};
+
+use crate::edit_modes::{AddingOrEditing, EditDisplayModes, HIGHLIGHT_COLOR};
+use crate::structured_modes::{MatchCondition, MatchOperator};
+
+#[derive(Debug, Clone)]
+pub struct NodeFilter {
+    pub name: String,
+    pub rules: Vec<NodeRule>,
+    /// Built-in filters (everything, etc.) are not editable.
+    pub is_editable: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct NodeRule {
+    pub name: String,
+    pub condition: MatchCondition,
+    pub visible: bool,
+}
+
+impl NodeFilter {
+    pub fn show_all() -> NodeFilter {
+        NodeFilter {
+            name: "Show all".to_string(),
+            rules: vec![NodeRule {
+                name: "Show all".to_string(),
+                condition: MatchCondition::any(),
+                visible: true,
+            }],
+            is_editable: false,
+        }
+    }
+
+    pub fn should_show_span(&self, node_name: &str) -> bool {
+        for rule in &self.rules {
+            if rule.condition.matches(node_name) {
+                return rule.visible;
+            }
+        }
+        false
+    }
+}
+
+#[derive(Debug)]
+pub struct EditNodeFilters {
+    state: EditNodeFiltersState,
+    filters: Vec<NodeFilter>,
+    max_width: f32,
+    selected_filter_idx: usize,
+    selected_rule_idx: usize,
+    current_filter: NodeFilter,
+    current_rule: NodeRule,
+    editing_or_adding_filter: AddingOrEditing,
+    editing_or_adding_rule: AddingOrEditing,
+    not_editable_message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EditNodeFiltersState {
+    Closed,
+    Open,
+    CloningFilter,
+    DeleteFilterConfirmation,
+    NotEditableError,
+    EditingFilter,
+    EditingFilterRule,
+}
+
+impl EditNodeFilters {
+    pub fn new() -> EditNodeFilters {
+        EditNodeFilters {
+            state: EditNodeFiltersState::Closed,
+            filters: vec![],
+            max_width: 800.0,
+            selected_rule_idx: 0,
+            selected_filter_idx: 0,
+            current_filter: Self::new_filter(),
+            current_rule: Self::new_rule(),
+            editing_or_adding_filter: AddingOrEditing::Adding,
+            editing_or_adding_rule: AddingOrEditing::Adding,
+            not_editable_message: String::new(),
+        }
+    }
+
+    pub fn open(&mut self, filters: Vec<NodeFilter>) {
+        self.filters = filters;
+        self.state = EditNodeFiltersState::Open;
+    }
+
+    pub fn draw(
+        &mut self,
+        _ui: &mut Ui,
+        ctx: &egui::Context,
+        max_width: f32,
+        max_height: f32,
+    ) -> Option<Vec<NodeFilter>> {
+        if self.state == EditNodeFiltersState::Closed {
+            return None;
+        }
+
+        let mut result = None;
+        self.max_width = max_width;
+        Modal::new("edit node filters".into()).show(ctx, |ui| {
+            ui.set_max_width(max_width);
+            ui.set_max_height(max_height);
+            match self.state {
+                EditNodeFiltersState::Closed => unreachable!(),
+                EditNodeFiltersState::Open => result = self.draw_open(ui, ctx),
+                EditNodeFiltersState::CloningFilter => self.draw_cloning_filter(ui, ctx),
+                EditNodeFiltersState::DeleteFilterConfirmation => {
+                    self.draw_delete_confirmation(ui, ctx)
+                }
+                EditNodeFiltersState::NotEditableError => self.draw_not_editable_error(ui, ctx),
+                EditNodeFiltersState::EditingFilter => self.draw_edit_filter(ui, ctx),
+                EditNodeFiltersState::EditingFilterRule => self.draw_edit_filter_rule(ui, ctx),
+            }
+        });
+
+        result
+    }
+
+    fn draw_open(&mut self, ui: &mut Ui, _ctx: &egui::Context) -> Option<Vec<NodeFilter>> {
+        ui.label("Node filters");
+        ScrollArea::vertical()
+            .id_salt("node filters")
+            .show(ui, |ui| {
+                for (index, filter) in self.filters.iter().enumerate() {
+                    let button = if self.selected_filter_idx == index {
+                        Button::new(filter.name.clone()).fill(HIGHLIGHT_COLOR)
+                    } else {
+                        Button::new(filter.name.clone())
+                    };
+                    if button.ui(ui).clicked() {
+                        self.selected_filter_idx = index;
+                    }
+                }
+            });
+
+        self.draw_short_separator(ui);
+
+        ui.horizontal(|ui| {
+            if ui.button("New Filter").clicked() {
+                self.current_filter = Self::new_filter();
+                self.selected_rule_idx = 0;
+                self.editing_or_adding_filter = AddingOrEditing::Adding;
+                self.state = EditNodeFiltersState::EditingFilter;
+            }
+            if ui.button("Edit Filter").clicked() {
+                if let Some(filter) = self.filters.get(self.selected_filter_idx) {
+                    if filter.is_editable {
+                        self.current_filter = filter.clone();
+                    self.selected_rule_idx = 0;
+                    self.editing_or_adding_filter = AddingOrEditing::Editing;
+                    self.state = EditNodeFiltersState::EditingFilter;
+                    } else {
+                        self.not_editable_message = "This filter is not editable! Builtin filters that are provided in traviz cannot be changed from the UI. You can clone this filter to create your own custom one and then edit the custom filter".to_string();
+                    }
+                    
+                }
+            }
+            if ui.button("Clone Filter").clicked() {
+                let mut new_filter = self.filters[self.selected_filter_idx].clone();
+                new_filter.name = format!("{} Clone", new_filter.name);
+                new_filter.is_editable = true;
+                self.state = EditNodeFiltersState::CloningFilter;
+                self.current_filter = new_filter;
+            }
+            if ui.button("Delete Filter").clicked() {
+                if let Some(filter) = self.filters.get(self.selected_filter_idx) {
+                    if filter.is_editable {
+                        self.state = EditNodeFiltersState::DeleteFilterConfirmation;
+                    } else {
+                        self.not_editable_message = "Builtin filters can not be deleted".to_string();
+                        self.state = EditNodeFiltersState::NotEditableError;
+                    }
+                }
+            }
+        });
+
+        let mut result = None;
+
+        self.draw_short_separator(ui);
+        ui.horizontal(|ui| {
+            if ui.button("Save").clicked() {
+                self.state = EditNodeFiltersState::Closed;
+                result = Some(std::mem::take(&mut self.filters));
+            }
+            if ui.button("Cancel").clicked() {
+                self.state = EditNodeFiltersState::Closed;
+            }
+        });
+
+        result
+    }
+
+    fn draw_cloning_filter(&mut self, ui: &mut Ui, _ctx: &egui::Context) {
+        ui.label("Clone Filter");
+        self.draw_short_separator(ui);
+
+        ui.horizontal(|ui| {
+            ui.label("Filter Name:");
+            ui.text_edit_singleline(&mut self.current_filter.name);
+        });
+
+        self.draw_short_separator(ui);
+        if ui.button("Clone").clicked() {
+            self.filters.push(self.current_filter.clone());
+            self.selected_filter_idx = self.filters.len() - 1;
+            self.state = EditNodeFiltersState::Open;
+        }
+        if ui.button("Cancel").clicked() {
+            self.state = EditNodeFiltersState::Open;
+        }
+    }
+
+    fn draw_delete_confirmation(&mut self, ui: &mut Ui, _ctx: &egui::Context) {
+        ui.label("Are you sure you want to delete this filter?");
+        self.draw_short_separator(ui);
+
+        if let Some(filter) = self.filters.get(self.selected_filter_idx) {
+            ui.label(format!("Filter Name: {}", filter.name));
+        }
+
+        self.draw_short_separator(ui);
+        if ui.button("Yes, Delete").clicked() {
+            self.filters.remove(self.selected_filter_idx);
+            self.selected_filter_idx = 0;
+            self.state = EditNodeFiltersState::Open;
+        }
+        if ui.button("No, Cancel").clicked() {
+            self.state = EditNodeFiltersState::Open;
+        }
+    }
+
+    fn draw_not_editable_error(&mut self, ui: &mut Ui, _ctx: &egui::Context) {
+        ui.label(&self.not_editable_message);
+        self.draw_short_separator(ui);
+        if ui.button("Ok").clicked() {
+            self.state = EditNodeFiltersState::Open;
+        }
+    }
+
+    fn draw_edit_filter(&mut self, ui: &mut Ui, _ctx: &egui::Context) {
+        ui.label("Editing Filter");
+        self.draw_short_separator(ui);
+        ui.horizontal(|ui| {
+            ui.label("Filter Name:");
+            ui.text_edit_singleline(&mut self.current_filter.name);
+        });
+        ui.horizontal(|ui| {
+            ui.vertical(|ui| {
+                ui.label("Filter Rules");
+                ScrollArea::vertical()
+                    .id_salt("filter rules")
+                    .show(ui, |ui| {
+                        for (index, rule) in self.current_filter.rules.iter().enumerate() {
+                            let button = if self.selected_rule_idx == index {
+                                Button::new(rule.name.to_string()).fill(HIGHLIGHT_COLOR)
+                            } else {
+                                Button::new(rule.name.to_string())
+                            };
+                            if button.ui(ui).clicked() {
+                                self.selected_rule_idx = index;
+                            }
+                        }
+                    });
+            });
+        });
+        self.draw_short_separator(ui);
+        ui.horizontal(|ui| {
+            if ui.button("New Rule").clicked() {
+                self.current_rule = Self::new_rule();
+                self.state = EditNodeFiltersState::EditingFilterRule;
+                self.editing_or_adding_rule = AddingOrEditing::Adding;
+            };
+            if ui.button("Edit").clicked() {
+                if let Some(rule) = self.current_filter.rules.get(self.selected_rule_idx) {
+                    self.current_rule = rule.clone();
+                    self.state = EditNodeFiltersState::EditingFilterRule;
+                    self.editing_or_adding_rule = AddingOrEditing::Editing;
+                }
+            }
+            if ui.button("Delete").clicked()
+                && self.selected_rule_idx < self.current_filter.rules.len()
+            {
+                self.current_filter.rules.remove(self.selected_rule_idx);
+                if self.selected_rule_idx >= self.current_filter.rules.len() {
+                    if self.current_filter.rules.is_empty() {
+                        self.selected_filter_idx = 0;
+                    } else {
+                        self.selected_filter_idx = self.current_filter.rules.len() - 1;
+                    }
+                }
+            }
+            if ui.button("Move up").clicked() && self.selected_rule_idx > 0 {
+                self.current_filter
+                    .rules
+                    .swap(self.selected_filter_idx, self.selected_filter_idx - 1);
+                self.selected_filter_idx -= 1;
+            }
+            if ui.button("Move down").clicked()
+                && self.selected_rule_idx < self.current_filter.rules.len() - 1
+            {
+                self.current_filter
+                    .rules
+                    .swap(self.selected_rule_idx, self.selected_rule_idx + 1);
+                self.selected_rule_idx += 1;
+            }
+        });
+        self.draw_short_separator(ui);
+        ui.horizontal(|ui| {
+            if ui.button("Ok").clicked() {
+                match self.editing_or_adding_filter {
+                    AddingOrEditing::Adding => {
+                        self.filters.push(self.current_filter.clone());
+                        self.selected_filter_idx = self.filters.len() - 1;
+                        self.state = EditNodeFiltersState::Open;
+                    }
+                    AddingOrEditing::Editing => {
+                        *self.filters.get_mut(self.selected_filter_idx).unwrap() =
+                            self.current_filter.clone();
+                        self.state = EditNodeFiltersState::Open;
+                    }
+                }
+            }
+            if ui.button("Cancel").clicked() {
+                self.state = EditNodeFiltersState::Open;
+            };
+        });
+    }
+
+    fn draw_edit_filter_rule(&mut self, ui: &mut Ui, _ctx: &egui::Context) {
+        ui.label("Editing Rule");
+        self.draw_short_separator(ui);
+        ui.horizontal(|ui| {
+            ui.label("Rule Name:");
+            ui.text_edit_singleline(&mut self.current_rule.name);
+        });
+        self.draw_short_separator(ui);
+        ui.label("Node name condition:");
+        EditDisplayModes::draw_edit_match_condition(
+            ui,
+            &mut self.current_rule.condition,
+            "node name condition",
+        );
+        self.draw_short_separator(ui);
+        ui.label("Decision");
+        ui.horizontal(|ui| {
+            ui.checkbox(&mut self.current_rule.visible, "Visible");
+        });
+        self.draw_short_separator(ui);
+        ui.horizontal(|ui| {
+            if ui.button("Ok").clicked() {
+                match self.editing_or_adding_rule {
+                    AddingOrEditing::Adding => {
+                        self.current_filter.rules.push(self.current_rule.clone());
+                        self.selected_rule_idx = self.current_filter.rules.len() - 1;
+                        self.state = EditNodeFiltersState::EditingFilter;
+                    }
+                    AddingOrEditing::Editing => {
+                        self.current_filter.rules[self.selected_rule_idx] =
+                            self.current_rule.clone();
+                        self.state = EditNodeFiltersState::EditingFilter;
+                    }
+                }
+            }
+            if ui.button("Cancel").clicked() {
+                self.state = EditNodeFiltersState::EditingFilter;
+            }
+        });
+    }
+
+    fn new_filter() -> NodeFilter {
+        NodeFilter {
+            name: "New Filter".to_string(),
+            rules: vec![Self::new_rule()],
+            is_editable: true,
+        }
+    }
+
+    fn new_rule() -> NodeRule {
+        NodeRule {
+            name: "Show my_node".to_string(),
+            condition: MatchCondition {
+                operator: MatchOperator::EqualTo,
+                value: "my_node".to_string(),
+            },
+            visible: true,
+        }
+    }
+
+    fn draw_short_separator(&self, ui: &mut Ui) {
+        ui.set_max_width(10.0);
+        ui.separator();
+        ui.set_max_width(self.max_width);
+    }
+}

--- a/src/node_filter.rs
+++ b/src/node_filter.rs
@@ -89,7 +89,6 @@ impl EditNodeFilters {
 
     pub fn draw(
         &mut self,
-        _ui: &mut Ui,
         ctx: &egui::Context,
         max_width: f32,
         max_height: f32,

--- a/src/types.rs
+++ b/src/types.rs
@@ -74,7 +74,7 @@ pub struct SpanDisplayConfig {
     pub display_length: DisplayLength,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DisplayLength {
     /// Span is displayed from start time to end time, length is equal to length of the interval
     Time,
@@ -94,7 +94,11 @@ pub fn value_to_text(value_opt: &Option<Value>) -> String {
         Value::DoubleValue(d) => d.to_string(),
         Value::ArrayValue(a) => format!(
             "[{}]",
-            a.values.iter().map(|v| value_to_text(&v.value)).collect::<Vec<_>>().join(", ")
+            a.values
+                .iter()
+                .map(|v| value_to_text(&v.value))
+                .collect::<Vec<_>>()
+                .join(", ")
         ),
         Value::KvlistValue(kv) => format!(
             "{{{}}}",


### PR DESCRIPTION
This PR adds functionality to edit display modes and node filters from the UI

![image](https://github.com/user-attachments/assets/08563d58-a647-46c0-94ec-0b1f9ab9cb7b)

Display modes define which spans should be displayed and how.
Each display mode consists of a list of rules. A rule has a selector which decides whether the rule applies to some span, and a decision that defines how a span matching the rule will be displayed.

Node filters define which nodes will be visible.
Each node filter is also a list of rules which say whether a node matching the selector should be displayed or not.
Filtering is purely visual for now - it just changes the drawing logic, but `spans_to_display` isn't affected by node filters, which could cause problems for search and analysis. Will be fixed in the future.

The UI is a bit rough and unintuitive, but it works and I was able to use it to achieve the same views as I did before by editing the code.

There is no persistence yet, will be added in a future PR.