### PR TITLE
add block production mode

### DIFF
--- a/src/structured_modes.rs
+++ b/src/structured_modes.rs
@@ -258,10 +258,10 @@ pub fn block_production_structured_mode() -> StructuredMode {
                     span_name_condition: MatchCondition::any(),
                     node_name_condition: MatchCondition::any(),
                     attribute_conditions: vec![(
-                        "tag".to_string(),
+                        "tag_block_production".to_string(),
                         MatchCondition {
                             operator: MatchOperator::EqualTo,
-                            value: "block_production".to_string(),
+                            value: "true".to_string(),
                         },
                     )],
                 },


### PR DESCRIPTION
This adds a new builtin mode called "block production" that shows only spans tagged with "block_production" and applies a few span name shortening mods.