### PR TITLE
Add original.span.name attribute to spans that had their name replaced

### DIFF
--- a/src/modes.rs
+++ b/src/modes.rs
@@ -86,6 +86,10 @@ fn structured_mode_transformation_rek(
         modified_span.collapse_children.set(true);
     }
     if !decision.replace_name.is_empty() {
+        modified_span.attributes.insert(
+            "original.span.name".to_string(),
+            Some(Value::StringValue(modified_span.name.clone())),
+        );
         modified_span.name = decision.replace_name;
     }
     if decision.add_height_to_name {


### PR DESCRIPTION
Makes it easier to figure out what was the original span name before it got replaced.
So we'll have a `VCSW` span with attribute `original.span.name = validate_chunk_state_witness`

Looks like typical attribute names use dot instead of space, so that's what I went with here: https://opentelemetry.io/docs/specs/semconv/general/attributes/