### PR TITLE
Ignore empty attribute conditions

### DIFF
--- a/src/edit_modes.rs
+++ b/src/edit_modes.rs
@@ -405,7 +405,7 @@ impl EditDisplayModes {
         }
         if ui.button("New Attribute Condition").clicked() {
             self.current_span_rule.selector.attribute_conditions.push((
-                "attr".to_string(),
+                "<attribute name>".to_string(),
                 MatchCondition {
                     operator: MatchOperator::EqualTo,
                     value: "val".to_string(),

--- a/src/structured_modes.rs
+++ b/src/structured_modes.rs
@@ -85,6 +85,12 @@ impl SpanSelector {
         }
 
         for (attr_name, attr_condition) in &self.attribute_conditions {
+            if attr_name.is_empty() || attr_name == "<attribute name>" {
+                // Ignore empty attribute conditions that have an empty or default name.
+                // They were probably added accidentally, it doesn't make much sense to enforce them.
+                continue;
+            }
+
             if let Some(attr_value) = span.attributes.get(attr_name) {
                 if !attr_condition.matches(&value_to_text(attr_value)) {
                     return false;


### PR DESCRIPTION
Ignore attribute conditions where the attribute name is empty or is equal to the default value inserted when an attribute condtion was created. Such conditions were probably created accidentally and it doesn't make much sense to enforce them.

I ran into this when I clicked "add attribute condition" while testing things, and then forgot about it and had to spend some time debugging why the rule isn't being applied correctly. It's unintuitive that an attribute condition with empty name is actually enforced, it looks like it's something that could be filled out when I wanted to add an actual condition there.