### PR TITLE
Add relations and relation views

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2974,6 +2974,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3429,6 +3440,8 @@ dependencies = [
  "rfd",
  "serde",
  "serde_json",
+ "sha2",
+ "uuid",
 ]
 
 [[package]]
@@ -3522,6 +3535,18 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "uuid"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
+dependencies = [
+ "getrandom 0.3.1",
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ rand = "0.9.1"
 rfd = "0.15.2"
 serde = "1.0.219"
 serde_json = "1.0.138"
+sha2 = "0.10.9"
+uuid = { version = "1.17.0", features = ["std", "serde", "v4"] }
 
 [features]
 default = []

--- a/src/edit_relations.rs
+++ b/src/edit_relations.rs
@@ -1,0 +1,684 @@
+use eframe::egui::{self, Button, ComboBox, Modal, ScrollArea, Ui, Vec2, Widget};
+use std::collections::HashMap;
+use uuid::Uuid;
+
+use crate::edit_modes::{AddingOrEditing, HIGHLIGHT_COLOR};
+use crate::relation::{
+    AttributeRelation, AttributeRelationOp, MatchType, Relation, RelationNodesConfig, RelationView,
+};
+
+#[derive(Clone, Debug)]
+pub struct EditRelations {
+    state: EditRelationsState,
+    relations: Vec<Relation>,
+    relation_views: Vec<RelationView>,
+    selected_relation_idx: usize,
+    current_relation: Relation,
+    editing_or_adding_relation: AddingOrEditing,
+    not_editable_message: String,
+    time_difference_string: String,
+    max_width: f32,
+    max_scrollarea_size: egui::Vec2,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum EditRelationsState {
+    Closed,
+    Open,
+    NotEditableError,
+    ConfirmDeletion,
+    EditingRelation,
+}
+
+impl EditRelations {
+    pub fn new() -> EditRelations {
+        EditRelations {
+            state: EditRelationsState::Closed,
+            relations: Vec::new(),
+            relation_views: Vec::new(),
+            selected_relation_idx: 0,
+            current_relation: Self::new_relation(),
+            editing_or_adding_relation: AddingOrEditing::Editing,
+            not_editable_message: String::new(),
+            time_difference_string: String::new(),
+            max_width: 0.0,
+            max_scrollarea_size: egui::Vec2::ZERO,
+        }
+    }
+
+    pub fn open(&mut self, relations: Vec<Relation>, relation_views: Vec<RelationView>) {
+        self.relations = relations;
+        self.relation_views = relation_views;
+        self.selected_relation_idx = 0;
+        self.state = EditRelationsState::Open;
+    }
+
+    pub fn draw(
+        &mut self,
+        max_width: f32,
+        max_height: f32,
+        ctx: &egui::Context,
+    ) -> Option<(Vec<Relation>, Vec<RelationView>)> {
+        if self.state == EditRelationsState::Closed {
+            return None;
+        }
+
+        self.max_width = max_width;
+        self.max_scrollarea_size = Vec2::new(max_width, max_height - 200.0);
+        let mut result = None;
+        Modal::new("edit relations".into()).show(ctx, |ui| {
+            ui.set_max_width(max_width);
+            ui.set_max_height(max_height);
+            match self.state {
+                EditRelationsState::Closed => unreachable!(),
+                EditRelationsState::Open => result = self.draw_open(ui, ctx),
+                EditRelationsState::ConfirmDeletion => self.draw_delete_confirmation(ui, ctx),
+                EditRelationsState::NotEditableError => self.draw_not_editable_error(ui, ctx),
+                EditRelationsState::EditingRelation => self.draw_editing_relation(ui, ctx),
+            }
+        });
+
+        result
+    }
+
+    fn draw_open(
+        &mut self,
+        ui: &mut Ui,
+        _ctx: &egui::Context,
+    ) -> Option<(Vec<Relation>, Vec<RelationView>)> {
+        ui.label("Edit releations");
+
+        self.draw_short_separator(ui);
+
+        ui.label("Relations");
+        ui.allocate_ui(self.max_scrollarea_size, |ui| {
+            ScrollArea::vertical().id_salt("relations").show(ui, |ui| {
+                let mut sorted_relations: Vec<(usize, &Relation)> =
+                    self.relations.iter().enumerate().collect::<Vec<_>>();
+                sorted_relations.sort_by_key(|r| &r.1.name);
+
+                for (index, relation) in sorted_relations {
+                    let relation_name = if relation.is_builtin {
+                        format!("{} (builtin)", relation.name)
+                    } else {
+                        relation.name.clone()
+                    };
+
+                    let button = if self.selected_relation_idx == index {
+                        Button::new(relation_name).fill(HIGHLIGHT_COLOR)
+                    } else {
+                        Button::new(relation_name)
+                    };
+                    if button.ui(ui).clicked() {
+                        self.selected_relation_idx = index;
+                    }
+                }
+            });
+        });
+
+        self.draw_short_separator(ui);
+
+        ui.label("Actions");
+        ui.horizontal(|ui| {
+            if ui.button("New Relation").clicked() {
+                let new_relation = Self::new_relation();
+                self.current_relation = new_relation.clone();
+                self.set_time_difference_string();
+                self.selected_relation_idx = 0;
+                self.editing_or_adding_relation = AddingOrEditing::Adding;
+                self.state = EditRelationsState::EditingRelation;
+            }
+            if ui.button("Edit Relation").clicked() {
+                if let Some(relation) = self.relations.get(self.selected_relation_idx) {
+                    if relation.is_builtin {
+                        self.not_editable_message =
+                        "This relation is not editable! Builtin relations that are provided in traviz cannot be changed from the UI. \
+                        You can clone this relation to create your own custom one and then edit the custom relation".to_string();
+                        self.state = EditRelationsState::NotEditableError;
+                    } else {
+                        self.current_relation = relation.clone();
+                        self.set_time_difference_string();
+                        self.editing_or_adding_relation = AddingOrEditing::Editing;
+                        self.state = EditRelationsState::EditingRelation;
+                    }
+                }
+            }
+            if ui.button("Clone Relation").clicked() {
+                let mut new_relation = self.relations[self.selected_relation_idx].clone();
+                new_relation.name = format!("{} Clone", new_relation.name);
+                new_relation.is_builtin = false;
+                self.relations.push(new_relation);
+                self.selected_relation_idx = self.relations.len() - 1;
+            }
+            if ui.button("Delete Relation").clicked() {
+                if let Some(relation) = self.relations.get(self.selected_relation_idx) {
+                    if relation.is_builtin {
+                        self.not_editable_message = "Builtin relations can not be deleted".to_string();
+                        self.state = EditRelationsState::NotEditableError;
+                    } else {
+                        self.state = EditRelationsState::ConfirmDeletion;
+                    }
+                }
+            }
+        });
+
+        let mut result = None;
+
+        self.draw_short_separator(ui);
+        ui.horizontal(|ui| {
+            if ui.button("Save").clicked() {
+                self.state = EditRelationsState::Closed;
+                result = Some((
+                    std::mem::take(&mut self.relations),
+                    std::mem::take(&mut self.relation_views),
+                ));
+            }
+            if ui.button("Cancel").clicked() {
+                self.state = EditRelationsState::Closed;
+            }
+        });
+
+        result
+    }
+
+    fn draw_delete_confirmation(&mut self, ui: &mut Ui, _ctx: &egui::Context) {
+        let Some(relation) = self.relations.get(self.selected_relation_idx) else {
+            self.state = EditRelationsState::Open;
+            return;
+        };
+
+        ui.label("Are you sure you want to delete this relation?");
+        self.draw_short_separator(ui);
+        ui.label(format!("Relation Name: {}", relation.name));
+        self.draw_short_separator(ui);
+        if ui.button("Yes, Delete").clicked() {
+            // First remove it from all relation views
+            for relation_view in &mut self.relation_views {
+                relation_view
+                    .enabled_relations
+                    .retain(|relation_id| *relation_id != relation.id);
+            }
+
+            self.relations.remove(self.selected_relation_idx);
+            self.selected_relation_idx = 0;
+            self.state = EditRelationsState::Open;
+        }
+        if ui.button("No, Cancel").clicked() {
+            self.state = EditRelationsState::Open;
+        }
+    }
+
+    fn draw_not_editable_error(&mut self, ui: &mut Ui, _ctx: &egui::Context) {
+        ui.label(&self.not_editable_message);
+        self.draw_short_separator(ui);
+        if ui.button("Ok").clicked() {
+            self.state = EditRelationsState::Open;
+        }
+    }
+
+    fn draw_editing_relation(&mut self, ui: &mut Ui, _ctx: &egui::Context) {
+        ui.label("Editing Relation");
+        self.draw_short_separator(ui);
+        ui.horizontal(|ui| {
+            ui.label("Relation name:");
+            ui.text_edit_singleline(&mut self.current_relation.name);
+        });
+        ui.horizontal(|ui| {
+            ui.label("From Span Name:");
+            ui.text_edit_singleline(&mut self.current_relation.from_span_name);
+        });
+        ui.horizontal(|ui| {
+            ui.label("To Span Name:");
+            ui.text_edit_singleline(&mut self.current_relation.to_span_name);
+        });
+        ui.label("Attribute Relations");
+        let mut attribute_relation_to_remove = None;
+        for (i, attr_condition) in &mut self
+            .current_relation
+            .attribute_relations
+            .iter_mut()
+            .enumerate()
+        {
+            ui.horizontal(|ui| {
+                ui.label("From attribute:");
+                ui.text_edit_singleline(&mut attr_condition.from_attribute);
+                ui.label("To attribute:");
+                ui.text_edit_singleline(&mut attr_condition.to_attribute);
+                ui.label("Relation:");
+                ComboBox::new(format!("relation operator {i}"), "")
+                    .selected_text(match attr_condition.relation {
+                        AttributeRelationOp::Equal => "Equal",
+                        AttributeRelationOp::OneGreater => "One greater",
+                    })
+                    .show_ui(ui, |ui| {
+                        ui.selectable_value(
+                            &mut attr_condition.relation,
+                            AttributeRelationOp::Equal,
+                            "Equal",
+                        );
+                        ui.selectable_value(
+                            &mut attr_condition.relation,
+                            AttributeRelationOp::OneGreater,
+                            "One greater",
+                        );
+                    });
+                if ui.button("Remove").clicked() {
+                    attribute_relation_to_remove = Some(i);
+                }
+            });
+        }
+        if let Some(idx) = attribute_relation_to_remove {
+            self.current_relation.attribute_relations.remove(idx);
+        }
+        if ui.button("New Attribute relation").clicked() {
+            self.current_relation
+                .attribute_relations
+                .push(AttributeRelation {
+                    from_attribute: "from attribute".to_string(),
+                    to_attribute: "to attribute".to_string(),
+                    relation: AttributeRelationOp::Equal,
+                });
+        }
+
+        self.draw_short_separator(ui);
+        ui.horizontal(|ui| {
+            ui.label("Max time difference (seconds):");
+            ui.text_edit_singleline(&mut self.time_difference_string);
+            if self.time_difference_string.is_empty() {
+                self.current_relation.max_time_diff = None;
+            } else if let Ok(value) = self.time_difference_string.parse::<f64>() {
+                self.current_relation.max_time_diff = Some(value);
+            } else {
+                ui.label("Can't parse value!");
+                self.current_relation.max_time_diff = None;
+            }
+        });
+        ui.horizontal(|ui| {
+            ui.label("Nodes config:");
+            ComboBox::new("nodes config", "")
+                .selected_text(match self.current_relation.nodes_config {
+                    RelationNodesConfig::AllNodes => "All nodes",
+                    RelationNodesConfig::SameNode => "Same node",
+                    RelationNodesConfig::DifferentNode => "Different node",
+                })
+                .show_ui(ui, |ui| {
+                    ui.selectable_value(
+                        &mut self.current_relation.nodes_config,
+                        RelationNodesConfig::AllNodes,
+                        "All nodes",
+                    );
+                    ui.selectable_value(
+                        &mut self.current_relation.nodes_config,
+                        RelationNodesConfig::SameNode,
+                        "Same Node",
+                    );
+                    ui.selectable_value(
+                        &mut self.current_relation.nodes_config,
+                        RelationNodesConfig::DifferentNode,
+                        "Different node",
+                    );
+                });
+        });
+
+        ui.horizontal(|ui| {
+            ui.label("Match type:");
+            ComboBox::new("match type", "")
+                .selected_text(match self.current_relation.match_type {
+                    MatchType::MatchAll => "Match all",
+                    MatchType::MatchClosest => "Match closest",
+                })
+                .show_ui(ui, |ui| {
+                    ui.selectable_value(
+                        &mut self.current_relation.match_type,
+                        MatchType::MatchAll,
+                        "Match all",
+                    );
+                    ui.selectable_value(
+                        &mut self.current_relation.match_type,
+                        MatchType::MatchClosest,
+                        "Match closest",
+                    );
+                });
+        });
+
+        ui.horizontal(|ui| {
+            if ui.button("Ok").clicked() {
+                match self.editing_or_adding_relation {
+                    AddingOrEditing::Adding => {
+                        self.relations.push(self.current_relation.clone());
+                        self.selected_relation_idx = self.relations.len() - 1;
+                        self.state = EditRelationsState::Open;
+                    }
+                    AddingOrEditing::Editing => {
+                        self.relations[self.selected_relation_idx] = self.current_relation.clone();
+                        self.state = EditRelationsState::Open;
+                    }
+                }
+            }
+            if ui.button("Cancel").clicked() {
+                self.state = EditRelationsState::Open;
+            }
+        });
+    }
+
+    fn draw_short_separator(&self, ui: &mut Ui) {
+        ui.set_max_width(10.0);
+        ui.separator();
+        ui.set_max_width(self.max_width);
+    }
+
+    fn new_relation() -> Relation {
+        Relation {
+            id: Uuid::new_v4(),
+            name: "New relation".to_string(),
+            from_span_name: "from span".to_string(),
+            to_span_name: "to span".to_string(),
+            attribute_relations: vec![],
+            max_time_diff: Some(10.0),
+            nodes_config: RelationNodesConfig::AllNodes,
+            match_type: MatchType::MatchAll,
+            is_builtin: false,
+        }
+    }
+
+    fn set_time_difference_string(&mut self) {
+        if let Some(max_time_diff) = self.current_relation.max_time_diff {
+            self.time_difference_string = max_time_diff.to_string();
+        } else {
+            self.time_difference_string = String::new();
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct EditRelationViews {
+    state: EditRelationViewsState,
+    relations: HashMap<Uuid, Relation>,
+    relation_views: Vec<RelationView>,
+    selected_relation_view_idx: usize,
+    current_relation_view: RelationView,
+    editing_or_adding_view: AddingOrEditing,
+    not_editable_message: String,
+    max_width: f32,
+    max_scrollarea_size: egui::Vec2,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum EditRelationViewsState {
+    Closed,
+    Open,
+    EditingRelationView,
+    NotEditableError,
+    ConfirmDeletion,
+}
+
+impl EditRelationViews {
+    pub fn new() -> EditRelationViews {
+        EditRelationViews {
+            state: EditRelationViewsState::Closed,
+            relations: HashMap::new(),
+            relation_views: Vec::new(),
+            selected_relation_view_idx: 0,
+            current_relation_view: RelationView {
+                enabled_relations: Vec::new(),
+                name: String::new(),
+                is_builtin: false,
+            },
+            editing_or_adding_view: AddingOrEditing::Editing,
+            not_editable_message: String::new(),
+            max_width: 0.0,
+            max_scrollarea_size: egui::Vec2::ZERO,
+        }
+    }
+
+    pub fn open(&mut self, relations: Vec<Relation>, relation_views: Vec<RelationView>) {
+        self.relations = relations
+            .into_iter()
+            .map(|relation| (relation.id, relation))
+            .collect();
+        self.relation_views = relation_views;
+        self.selected_relation_view_idx = 0;
+        self.state = EditRelationViewsState::Open;
+    }
+
+    pub fn draw(
+        &mut self,
+        max_width: f32,
+        max_height: f32,
+        ctx: &egui::Context,
+    ) -> Option<Vec<RelationView>> {
+        if self.state == EditRelationViewsState::Closed {
+            return None;
+        }
+
+        self.max_width = max_width;
+        self.max_scrollarea_size = Vec2::new(max_width, max_height - 200.0);
+        let mut result = None;
+        Modal::new("edit relation views".into()).show(ctx, |ui| {
+            ui.set_max_width(max_width);
+            ui.set_max_height(max_height);
+            match self.state {
+                EditRelationViewsState::Closed => unreachable!(),
+                EditRelationViewsState::Open => result = self.draw_open(ui, ctx),
+                EditRelationViewsState::ConfirmDeletion => self.draw_delete_confirmation(ui, ctx),
+                EditRelationViewsState::NotEditableError => self.draw_not_editable_error(ui, ctx),
+                EditRelationViewsState::EditingRelationView => {
+                    self.draw_editing_relation_view(ui, ctx)
+                }
+            }
+        });
+
+        result
+    }
+
+    fn draw_open(&mut self, ui: &mut Ui, _ctx: &egui::Context) -> Option<Vec<RelationView>> {
+        ui.label("Edit relation views");
+
+        self.draw_short_separator(ui);
+
+        ui.label("Relation views");
+        ui.allocate_ui(self.max_scrollarea_size, |ui| {
+            ScrollArea::vertical().id_salt("relations").show(ui, |ui| {
+                for (index, relation_view) in self.relation_views.iter().enumerate() {
+                    let view_name = if relation_view.is_builtin {
+                        format!("{} (builtin)", relation_view.name)
+                    } else {
+                        relation_view.name.clone()
+                    };
+
+                    let button = if self.selected_relation_view_idx == index {
+                        Button::new(view_name).fill(HIGHLIGHT_COLOR)
+                    } else {
+                        Button::new(view_name)
+                    };
+                    if button.ui(ui).clicked() {
+                        self.selected_relation_view_idx = index;
+                    }
+                }
+            });
+        });
+
+        self.draw_short_separator(ui);
+
+        ui.label("Actions");
+        ui.horizontal(|ui| {
+            if ui.button("New Relation view").clicked() {
+                let new_relation_view = Self::new_view();
+                self.current_relation_view = new_relation_view.clone();
+                self.selected_relation_view_idx = 0;
+                self.editing_or_adding_view = AddingOrEditing::Adding;
+                self.state = EditRelationViewsState::EditingRelationView;
+            }
+            if ui.button("Edit Relation view").clicked() {
+                if let Some(relation_view) = self.relation_views.get(self.selected_relation_view_idx) {
+                    if relation_view.is_builtin {
+                        self.not_editable_message =
+                        "This relation view is not editable! Builtin relation views that are provided in traviz cannot be changed from the UI. \
+                        You can clone this relation view to create your own custom one and then edit the custom relation view".to_string();
+                        self.state = EditRelationViewsState::NotEditableError;
+                    } else {
+                        self.current_relation_view = relation_view.clone();
+                        self.editing_or_adding_view = AddingOrEditing::Editing;
+                        self.state = EditRelationViewsState::EditingRelationView;
+                    }
+                }
+            }
+            if ui.button("Clone Relation view").clicked() {
+                let mut new_relation_view = self.relation_views[self.selected_relation_view_idx].clone();
+                new_relation_view.name = format!("{} Clone", new_relation_view.name);
+                new_relation_view.is_builtin = false;
+                self.relation_views.push(new_relation_view);
+                self.selected_relation_view_idx = self.relation_views.len() - 1;
+            }
+            if ui.button("Delete Relation").clicked() {
+                if let Some(view) = self.relation_views.get(self.selected_relation_view_idx) {
+                    if view.is_builtin {
+                        self.not_editable_message = "Builtin relation views can not be deleted".to_string();
+                        self.state = EditRelationViewsState::NotEditableError;
+                    } else {
+                        self.state = EditRelationViewsState::ConfirmDeletion;
+                    }
+                }
+            }
+        });
+
+        let mut result = None;
+
+        self.draw_short_separator(ui);
+        ui.horizontal(|ui| {
+            if ui.button("Save").clicked() {
+                self.state = EditRelationViewsState::Closed;
+                result = Some(std::mem::take(&mut self.relation_views));
+            }
+            if ui.button("Cancel").clicked() {
+                self.state = EditRelationViewsState::Closed;
+            }
+        });
+
+        result
+    }
+
+    fn draw_delete_confirmation(&mut self, ui: &mut Ui, _ctx: &egui::Context) {
+        let Some(relation_view) = self.relation_views.get(self.selected_relation_view_idx) else {
+            self.state = EditRelationViewsState::Open;
+            return;
+        };
+
+        ui.label("Are you sure you want to delete this relation view?");
+        self.draw_short_separator(ui);
+        ui.label(format!("Relation view name: {}", relation_view.name));
+        self.draw_short_separator(ui);
+        if ui.button("Yes, Delete").clicked() {
+            self.relation_views.remove(self.selected_relation_view_idx);
+            self.selected_relation_view_idx = 0;
+            self.state = EditRelationViewsState::Open;
+        }
+        if ui.button("No, Cancel").clicked() {
+            self.state = EditRelationViewsState::Open;
+        }
+    }
+
+    fn draw_not_editable_error(&mut self, ui: &mut Ui, _ctx: &egui::Context) {
+        ui.label(&self.not_editable_message);
+        self.draw_short_separator(ui);
+        if ui.button("Ok").clicked() {
+            self.state = EditRelationViewsState::Open;
+        }
+    }
+
+    fn draw_editing_relation_view(&mut self, ui: &mut Ui, _ctx: &egui::Context) {
+        ui.label("Editing Relation View");
+        self.draw_short_separator(ui);
+        ui.horizontal(|ui| {
+            ui.label("Relation view name:");
+            ui.text_edit_singleline(&mut self.current_relation_view.name);
+        });
+        self.draw_short_separator(ui);
+
+        let mut all_relations: Vec<(String, Uuid, bool)> = self
+            .relations
+            .iter()
+            .map(|(relation_id, relation)| {
+                let is_enabled = self
+                    .current_relation_view
+                    .enabled_relations
+                    .contains(relation_id);
+                (relation.name.clone(), *relation_id, is_enabled)
+            })
+            .collect::<Vec<_>>();
+        for enabled_relation_id in &self.current_relation_view.enabled_relations {
+            if !self.relations.contains_key(enabled_relation_id) {
+                all_relations.push(("Unknown Relation".to_string(), *enabled_relation_id, true));
+            }
+        }
+        all_relations.sort_by_key(|(name, _, is_enabled)| (!is_enabled, name.clone()));
+
+        ui.allocate_ui(self.max_scrollarea_size, |ui| {
+            ScrollArea::vertical()
+                .id_salt("enabled relations")
+                .show(ui, |ui| {
+                    ui.label("Enabled relations");
+                    let mut first_disabled = true;
+                    for (relation_name, relation_id, mut enabled) in all_relations {
+                        if !enabled && first_disabled {
+                            ui.label("Disabled relations");
+                            first_disabled = false;
+                        }
+
+                        let was_enabled = enabled;
+
+                        ui.horizontal(|ui| {
+                            ui.checkbox(&mut enabled, "");
+                            ui.label(relation_name);
+                        });
+
+                        if was_enabled != enabled {
+                            if enabled {
+                                self.current_relation_view
+                                    .enabled_relations
+                                    .push(relation_id);
+                            } else {
+                                self.current_relation_view
+                                    .enabled_relations
+                                    .retain(|id| *id != relation_id);
+                            }
+                        }
+                    }
+                });
+        });
+
+        ui.horizontal(|ui| {
+            if ui.button("Ok").clicked() {
+                match self.editing_or_adding_view {
+                    AddingOrEditing::Adding => {
+                        self.relation_views.push(self.current_relation_view.clone());
+                        self.selected_relation_view_idx = self.relation_views.len() - 1;
+                        self.state = EditRelationViewsState::Open;
+                    }
+                    AddingOrEditing::Editing => {
+                        self.relation_views[self.selected_relation_view_idx] =
+                            self.current_relation_view.clone();
+                        self.state = EditRelationViewsState::Open;
+                    }
+                }
+            }
+            if ui.button("Cancel").clicked() {
+                self.state = EditRelationViewsState::Open;
+            }
+        });
+    }
+
+    fn draw_short_separator(&self, ui: &mut Ui) {
+        ui.set_max_width(10.0);
+        ui.separator();
+        ui.set_max_width(self.max_width);
+    }
+
+    fn new_view() -> RelationView {
+        RelationView {
+            enabled_relations: Vec::new(),
+            name: "New Relation View".to_string(),
+            is_builtin: false,
+        }
+    }
+}

--- a/src/modes.rs
+++ b/src/modes.rs
@@ -248,6 +248,9 @@ fn extract_spans(requests: &[ExportTraceServiceRequest]) -> Result<Vec<Rc<Span>>
                             display_start: Cell::new(0.0),
                             display_length: Cell::new(0.0),
                             time_display_length: Cell::new(0.0),
+
+                            incoming_relations: RefCell::new(Vec::new()),
+                            outgoing_relations: RefCell::new(Vec::new()),
                         }),
                     );
                 }

--- a/src/modes.rs
+++ b/src/modes.rs
@@ -85,11 +85,18 @@ fn structured_mode_transformation_rek(
         modified_span.dont_collapse_this_span.set(true);
         modified_span.collapse_children.set(true);
     }
-    if !decision.replace_name.is_empty() {
+
+    let will_change_name = !decision.replace_name.is_empty()
+        || decision.add_height_to_name
+        || decision.add_shard_id_to_name;
+    if will_change_name {
         modified_span.attributes.insert(
             "original.span.name".to_string(),
             Some(Value::StringValue(modified_span.name.clone())),
         );
+    }
+
+    if !decision.replace_name.is_empty() {
         modified_span.name = decision.replace_name;
     }
     if decision.add_height_to_name {

--- a/src/relation.rs
+++ b/src/relation.rs
@@ -1,0 +1,359 @@
+use std::collections::HashMap;
+use std::rc::{Rc, Weak};
+
+use sha2::Digest;
+use uuid::Uuid;
+
+use crate::task_timer::TaskTimer;
+use crate::types::{value_to_text, Span};
+
+pub fn make_uuid_from_seed(seed: &str) -> Uuid {
+    let digest_bytes: [u8; 32] = sha2::Sha256::digest(seed).into();
+    let uuid_bytes: [u8; 16] = digest_bytes[0..16].try_into().unwrap();
+    Uuid::from_bytes(uuid_bytes)
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct Relation {
+    pub id: Uuid,
+
+    pub name: String,
+    pub from_span_name: String,
+    pub to_span_name: String,
+    pub attribute_relations: Vec<AttributeRelation>,
+    pub max_time_diff: Option<f64>,
+
+    pub nodes_config: RelationNodesConfig,
+    pub match_type: MatchType,
+
+    pub is_builtin: bool,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct AttributeRelation {
+    pub from_attribute: String,
+    pub to_attribute: String,
+    pub relation: AttributeRelationOp,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum AttributeRelationOp {
+    Equal,
+    OneGreater,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum RelationNodesConfig {
+    SameNode,
+    DifferentNode,
+    AllNodes,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum MatchType {
+    MatchAll,
+    MatchClosest,
+}
+
+impl Relation {
+    pub fn matches(&self, from_span: &Span, to_span: &Span) -> bool {
+        if from_span.original_name() != self.from_span_name {
+            return false;
+        }
+        if to_span.original_name() != self.to_span_name {
+            return false;
+        }
+
+        for attribute_relation in &self.attribute_relations {
+            if !attribute_relation.matches(from_span, to_span) {
+                return false; // If any attribute relation does not match, the relation does not match
+            }
+        }
+
+        match &self.nodes_config {
+            RelationNodesConfig::SameNode => {
+                if from_span.node.name != to_span.node.name {
+                    return false; // Spans must be in the same node
+                }
+            }
+            RelationNodesConfig::DifferentNode => {
+                if from_span.node.name == to_span.node.name {
+                    return false; // Spans must be in different nodes
+                }
+            }
+            RelationNodesConfig::AllNodes => {
+                // No restriction on nodes
+            }
+        }
+
+        true
+    }
+}
+
+impl AttributeRelation {
+    fn matches(&self, from_span: &Span, to_span: &Span) -> bool {
+        let Some(from_value) = from_span.attributes.get(&self.from_attribute) else {
+            return false;
+        };
+        let Some(to_value) = to_span.attributes.get(&self.to_attribute) else {
+            return false;
+        };
+
+        match self.relation {
+            AttributeRelationOp::Equal => value_to_text(from_value) == value_to_text(to_value),
+            AttributeRelationOp::OneGreater => {
+                if let (Ok(from_num), Ok(to_num)) = (
+                    value_to_text(from_value).parse::<i64>(),
+                    value_to_text(to_value).parse::<i64>(),
+                ) {
+                    from_num.checked_add(1) == Some(to_num)
+                } else {
+                    false
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct RelationView {
+    pub enabled_relations: Vec<Uuid>,
+    pub name: String,
+    pub is_builtin: bool,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct RelationViews {
+    pub views: Vec<RelationView>,
+}
+
+#[derive(Debug, Clone)]
+pub struct RelationInstance {
+    pub from_span: Weak<Span>,
+    pub to_span: Weak<Span>,
+    #[allow(unused)]
+    pub relation: Rc<Relation>,
+}
+
+pub fn find_relations(
+    all_relations: &[Relation],
+    view: &RelationView,
+    spans: &[Rc<Span>],
+) -> Vec<RelationInstance> {
+    #[cfg(feature = "profiling")]
+    let _timing_guard = profiling::GLOBAL_PROFILER.start_timing("find_relations");
+
+    let task_timer = TaskTimer::new("Finding relations");
+
+    let mut res = Vec::new();
+
+    // Spans grouped by name, sorted by start time.
+    let mut spans_by_name: HashMap<String, Vec<Rc<Span>>> = HashMap::new();
+    for span in spans {
+        gather_spans_by_name(span, &mut spans_by_name);
+    }
+    for (_name, spans) in spans_by_name.iter_mut() {
+        // Sort spans by start time
+        spans.sort_by(|a, b| {
+            a.start_time
+                .partial_cmp(&b.start_time)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+
+        // Clear outgoing and incoming relations for each span
+        for span in spans {
+            span.outgoing_relations.borrow_mut().clear();
+            span.incoming_relations.borrow_mut().clear();
+        }
+    }
+
+    for enabled_relation_id in &view.enabled_relations {
+        let Some(relation) = all_relations.iter().find(|r| &r.id == enabled_relation_id) else {
+            continue;
+        };
+        let relation = Rc::new(relation.clone());
+
+        let Some(from_spans) = spans_by_name.get(&relation.from_span_name) else {
+            continue;
+        };
+        let Some(to_spans) = spans_by_name.get(&relation.to_span_name) else {
+            continue;
+        };
+
+        for from_span in from_spans {
+            let first_to_span_index = find_first_span_after(to_spans, from_span.end_time);
+            for to_span in &to_spans[first_to_span_index..] {
+                if let Some(max_time_diff) = relation.max_time_diff {
+                    if to_span.start_time - from_span.start_time > max_time_diff {
+                        break;
+                    }
+                }
+
+                if !relation.matches(from_span, to_span) {
+                    continue;
+                }
+
+                let instance = RelationInstance {
+                    from_span: Rc::<Span>::downgrade(from_span),
+                    to_span: Rc::<Span>::downgrade(to_span),
+                    relation: relation.clone(),
+                };
+
+                from_span
+                    .outgoing_relations
+                    .borrow_mut()
+                    .push(instance.clone());
+                to_span
+                    .incoming_relations
+                    .borrow_mut()
+                    .push(instance.clone());
+                res.push(instance);
+
+                match relation.match_type {
+                    MatchType::MatchAll => {
+                        // For MatchAll, we continue to find more matches
+                        continue;
+                    }
+                    MatchType::MatchClosest => {
+                        // For MatchClosest, we break after the first match
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    task_timer.stop();
+    println!("Found {} relations", res.len());
+
+    res
+}
+
+fn gather_spans_by_name(span: &Rc<Span>, spans_by_name: &mut HashMap<String, Vec<Rc<Span>>>) {
+    spans_by_name
+        .entry(span.original_name().to_string())
+        .or_default()
+        .push(span.clone());
+    for child in span.children.borrow().iter() {
+        gather_spans_by_name(child, spans_by_name);
+    }
+}
+
+fn find_first_span_after(spans: &[Rc<Span>], start_time: f64) -> usize {
+    // TODO - this could be optimized with binary search
+    spans
+        .iter()
+        .position(|span| span.start_time >= start_time)
+        .unwrap_or(spans.len())
+}
+
+fn pre_post_process_block_relation() -> Relation {
+    Relation {
+        id: make_uuid_from_seed("pre-post-process block"),
+        name: "pre-post-process block".to_string(),
+        from_span_name: "preprocess_block".to_string(),
+        to_span_name: "postprocess_ready_block".to_string(),
+        attribute_relations: vec![AttributeRelation {
+            from_attribute: "height".to_string(),
+            to_attribute: "height".to_string(),
+            relation: AttributeRelationOp::Equal,
+        }],
+        max_time_diff: Some(5.0), // 5 seconds
+        nodes_config: RelationNodesConfig::SameNode,
+        match_type: MatchType::MatchClosest,
+        is_builtin: true,
+    }
+}
+
+fn send_receive_witness_relation() -> Relation {
+    Relation {
+        id: make_uuid_from_seed("send-validate witness"),
+        name: "send-receive witness".to_string(),
+        from_span_name: "send_chunk_state_witness".to_string(),
+        to_span_name: "validate_chunk_state_witness".to_string(),
+        attribute_relations: vec![
+            AttributeRelation {
+                from_attribute: "height".to_string(),
+                to_attribute: "height".to_string(),
+                relation: AttributeRelationOp::Equal,
+            },
+            AttributeRelation {
+                from_attribute: "shard_id".to_string(),
+                to_attribute: "shard_id".to_string(),
+                relation: AttributeRelationOp::Equal,
+            },
+        ],
+        max_time_diff: Some(5.0), // 5 seconds
+        nodes_config: RelationNodesConfig::AllNodes,
+        match_type: MatchType::MatchAll,
+        is_builtin: true,
+    }
+}
+
+fn send_validate_chunk_endorsement() -> Relation {
+    Relation {
+        id: make_uuid_from_seed("send-validate chunk endorsement"),
+        name: "send-validate chunk endorsement".to_string(),
+        from_span_name: "send_chunk_endorsement".to_string(),
+        to_span_name: "validate_chunk_endorsement".to_string(),
+        attribute_relations: vec![
+            AttributeRelation {
+                from_attribute: "height".to_string(),
+                to_attribute: "height".to_string(),
+                relation: AttributeRelationOp::Equal,
+            },
+            AttributeRelation {
+                from_attribute: "shard_id".to_string(),
+                to_attribute: "shard_id".to_string(),
+                relation: AttributeRelationOp::Equal,
+            },
+            AttributeRelation {
+                from_attribute: "validator".to_string(),
+                to_attribute: "validator".to_string(),
+                relation: AttributeRelationOp::Equal,
+            },
+        ],
+        max_time_diff: Some(5.0), // 5 seconds
+        nodes_config: RelationNodesConfig::AllNodes,
+        match_type: MatchType::MatchAll,
+        is_builtin: true,
+    }
+}
+
+pub fn builtin_relations() -> Vec<Relation> {
+    vec![
+        pre_post_process_block_relation(),
+        send_receive_witness_relation(),
+        send_validate_chunk_endorsement(),
+    ]
+}
+
+pub fn builtin_relation_views() -> Vec<RelationView> {
+    vec![
+        RelationView {
+            name: "No relations".to_string(),
+            enabled_relations: vec![],
+            is_builtin: true,
+        },
+        RelationView {
+            name: "Pre-Post Process Block".to_string(),
+            enabled_relations: vec![pre_post_process_block_relation().id],
+            is_builtin: true,
+        },
+        RelationView {
+            name: "Send-Receive Witness".to_string(),
+            enabled_relations: vec![send_receive_witness_relation().id],
+            is_builtin: true,
+        },
+        RelationView {
+            name: "Send-Validate Chunk Endorsement".to_string(),
+            enabled_relations: vec![send_validate_chunk_endorsement().id],
+            is_builtin: true,
+        },
+        RelationView {
+            name: "All builtin Relations".to_string(),
+            enabled_relations: builtin_relations().iter().map(|r| r.id).collect(),
+            is_builtin: true,
+        },
+    ]
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -6,6 +6,8 @@ use std::rc::Rc;
 
 use opentelemetry_proto::tonic::common::v1::any_value::Value;
 
+use crate::relation::{Relation, RelationInstance};
+
 pub const MILLISECONDS_PER_SECOND: f64 = 1000.0;
 
 /// Seconds since epoch
@@ -51,6 +53,9 @@ pub struct Span {
     pub display_start: Cell<f32>,
     pub display_length: Cell<f32>,
     pub time_display_length: Cell<f32>,
+
+    pub incoming_relations: RefCell<Vec<RelationInstance>>,
+    pub outgoing_relations: RefCell<Vec<RelationInstance>>,
 }
 
 impl Span {
@@ -64,6 +69,11 @@ impl Span {
             }
         }
         false
+    }
+
+    pub fn original_name(&self) -> &str {
+        // TODO - should this be a field or an attribute?
+        &self.original_name
     }
 }
 


### PR DESCRIPTION
This PR adds two new concepts: relations and relation views

`Relation` is a link between two spans - from a span with some name to a span with another name, with some additional conditions on attributes and node names.

```rust
#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
pub struct Relation {
    pub id: Uuid,

    pub name: String,
    pub from_span_name: String,
    pub to_span_name: String,
    pub attribute_relations: Vec<AttributeRelation>,
    pub max_time_diff: Option<f64>,

    pub nodes_config: RelationNodesConfig,
    pub match_type: MatchType,

    pub is_builtin: bool,
}
```

Then a relation view defines which of the relations should be active and visible in traviz:

```rust
#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
pub struct RelationView {
    pub enabled_relations: Vec<Uuid>,
    pub name: String,
    pub is_builtin: bool,
}
```

This allows to connect spans together and observe how the data flows.

![image](https://github.com/user-attachments/assets/63fe749f-e35e-4522-8ebb-0ae91d6d9a34)

The relations and relation views are editable from the UI.
The data model is slightly different from the previous display modes and node filters - here we have one global list of relations with unique Uuids and each relation view chooses which relations from this global list should be visible.

There is probably a lot of overlap with analyze dependency, but I didn't spend much time on merging them, for now I wanted to try out relations and see how useful they are.

For now it just draws the arrows, but in the future we could:
* Show a list of incoming and outgoing relations in span info
* Allow jumping between spans using the relations
* Define dependencies as a collection of relations and run analysis on them