### PR TITLE
Allow dependency analysis on the same span type

### DIFF
--- a/src/analyze_dependency.rs
+++ b/src/analyze_dependency.rs
@@ -671,11 +671,6 @@ impl AnalyzeDependencyModal {
             None => return Err("Target span not selected".to_string()),
         };
 
-        // Validate that source and target spans are different
-        if source_name == target_name {
-            return Err("Source and target spans must be different".to_string());
-        }
-
         // Collect all source and target spans
         let mut source_spans = Vec::new();
         let mut target_spans = Vec::new();


### PR DESCRIPTION
Relax the UI constraint that is preventing the same span type to be both source and destination.

One use case is computing statistics on block time , in which the user can now use analyze dependency on 'produce_block' -> 'produce_block'