### PR TITLE
More relations

### DIFF
--- a/src/builtin_relations.rs
+++ b/src/builtin_relations.rs
@@ -19,6 +19,7 @@ pub fn produce_block_on_head_to_preprocess_block_relation() -> Relation {
         max_time_diff: Some(5.0), // 5 seconds
         nodes_config: RelationNodesConfig::AllNodes,
         match_type: MatchType::MatchAll,
+        min_time_diff: 0.0,
         is_builtin: true,
     }
 }
@@ -38,6 +39,7 @@ pub fn preprocess_block_to_postprocess_ready_block_relation() -> Relation {
         max_time_diff: Some(5.0), // 5 seconds
         nodes_config: RelationNodesConfig::SameNode,
         match_type: MatchType::MatchAll,
+        min_time_diff: 0.0,
         is_builtin: true,
     }
 }
@@ -57,6 +59,7 @@ pub fn postprocess_ready_block_to_produce_block_on_head_relation() -> Relation {
         max_time_diff: Some(5.0), // 5 seconds
         nodes_config: RelationNodesConfig::SameNode,
         match_type: MatchType::MatchAll,
+        min_time_diff: 0.0,
         is_builtin: true,
     }
 }
@@ -76,6 +79,7 @@ pub fn postprocess_ready_block_to_next_preprocess_block_relation() -> Relation {
         max_time_diff: Some(5.0), // 5 seconds
         nodes_config: RelationNodesConfig::SameNode,
         match_type: MatchType::MatchAll,
+        min_time_diff: 0.0,
         is_builtin: true,
     }
 }
@@ -105,6 +109,7 @@ pub fn preprocess_block_to_apply_new_chunk_relation() -> Relation {
         max_time_diff: Some(5.0), // 5 seconds
         nodes_config: RelationNodesConfig::SameNode,
         match_type: MatchType::MatchAll,
+        min_time_diff: 0.0,
         is_builtin: true,
     }
 }
@@ -134,6 +139,7 @@ pub fn apply_new_chunk_normal_to_postprocess_ready_block_relation() -> Relation 
         max_time_diff: Some(5.0), // 5 seconds
         nodes_config: RelationNodesConfig::SameNode,
         match_type: MatchType::MatchAll,
+        min_time_diff: 0.0,
         is_builtin: true,
     }
 }
@@ -166,6 +172,7 @@ pub fn apply_new_chunk_optimistic_to_postprocess_ready_block_relation() -> Relat
         max_time_diff: Some(5.0), // 5 seconds
         nodes_config: RelationNodesConfig::SameNode,
         match_type: MatchType::MatchAll,
+        min_time_diff: 0.0,
         is_builtin: true,
     }
 }
@@ -185,6 +192,7 @@ pub fn postprocess_ready_block_to_produce_chunk_relation() -> Relation {
         max_time_diff: Some(5.0), // 5 seconds
         nodes_config: RelationNodesConfig::SameNode,
         match_type: MatchType::MatchAll,
+        min_time_diff: 0.0,
         is_builtin: true,
     }
 }
@@ -211,6 +219,7 @@ pub fn produce_chunk_to_send_chunk_state_witness_relation() -> Relation {
         max_time_diff: Some(5.0), // 5 seconds
         nodes_config: RelationNodesConfig::SameNode,
         match_type: MatchType::MatchAll,
+        min_time_diff: 0.0,
         is_builtin: true,
     }
 }
@@ -237,6 +246,7 @@ pub fn send_chunk_state_witness_to_validate_chunk_state_witness_relation() -> Re
         max_time_diff: Some(5.0), // 5 seconds
         nodes_config: RelationNodesConfig::AllNodes,
         match_type: MatchType::MatchAll,
+        min_time_diff: 0.0,
         is_builtin: true,
     }
 }
@@ -263,6 +273,7 @@ pub fn validate_chunk_state_witness_to_send_chunk_endorsement_relation() -> Rela
         max_time_diff: Some(5.0), // 5 seconds
         nodes_config: RelationNodesConfig::SameNode,
         match_type: MatchType::MatchAll,
+        min_time_diff: 0.0,
         is_builtin: true,
     }
 }
@@ -294,6 +305,7 @@ pub fn send_chunk_endorsement_to_validate_chunk_endorsement_relation() -> Relati
         max_time_diff: Some(5.0), // 5 seconds
         nodes_config: RelationNodesConfig::AllNodes,
         match_type: MatchType::MatchAll,
+        min_time_diff: 0.0,
         is_builtin: true,
     }
 }
@@ -312,6 +324,7 @@ pub fn validate_chunk_endorsement_to_produce_block_on_head_relation() -> Relatio
         max_time_diff: Some(5.0), // 5 seconds
         nodes_config: RelationNodesConfig::SameNode,
         match_type: MatchType::MatchAll,
+        min_time_diff: 0.0,
         is_builtin: true,
     }
 }
@@ -331,6 +344,7 @@ pub fn postprocess_ready_block_to_produce_optimistic_block_on_head_relation() ->
         max_time_diff: Some(5.0), // 5 seconds
         nodes_config: RelationNodesConfig::SameNode,
         match_type: MatchType::MatchAll,
+        min_time_diff: 0.0,
         is_builtin: true,
     }
 }
@@ -350,6 +364,7 @@ pub fn produce_optimistic_block_on_head_to_process_optimistic_block_relation() -
         max_time_diff: Some(5.0), // 5 seconds
         nodes_config: RelationNodesConfig::AllNodes,
         match_type: MatchType::MatchAll,
+        min_time_diff: 0.0,
         is_builtin: true,
     }
 }
@@ -382,6 +397,7 @@ pub fn process_optimistic_block_to_apply_new_chunk_optimistic_relation() -> Rela
         max_time_diff: Some(5.0), // 5 seconds
         nodes_config: RelationNodesConfig::SameNode,
         match_type: MatchType::MatchAll,
+        min_time_diff: -0.010, // apply_new_chunk sometimes happens a few ms before the process_optimistic_block that spawns it.
         is_builtin: true,
     }
 }

--- a/src/builtin_relations.rs
+++ b/src/builtin_relations.rs
@@ -1,0 +1,411 @@
+use crate::relation::{
+    make_uuid_from_seed, AttributeRelation, AttributeRelationOp, MatchType, Relation,
+    RelationNodesConfig,
+};
+use crate::structured_modes::{MatchCondition, SpanSelector};
+
+pub fn produce_block_on_head_to_preprocess_block_relation() -> Relation {
+    Relation {
+        id: make_uuid_from_seed("produce_block_on_head -> preprocess_block"),
+        name: "produce_block_on_head -> preprocess_block".to_string(),
+        description: "".to_string(),
+        from_span_selector: SpanSelector::new_equal_name("produce_block_on_head"),
+        to_span_selector: SpanSelector::new_equal_name("preprocess_block"),
+        attribute_relations: vec![AttributeRelation {
+            from_attribute: "height".to_string(),
+            to_attribute: "height".to_string(),
+            relation: AttributeRelationOp::Equal,
+        }],
+        max_time_diff: Some(5.0), // 5 seconds
+        nodes_config: RelationNodesConfig::AllNodes,
+        match_type: MatchType::MatchAll,
+        is_builtin: true,
+    }
+}
+
+pub fn preprocess_block_to_postprocess_ready_block_relation() -> Relation {
+    Relation {
+        id: make_uuid_from_seed("pre-post-process block"),
+        name: "preprocess_block -> postprocess_ready_block".to_string(),
+        description: "".to_string(),
+        from_span_selector: SpanSelector::new_equal_name("preprocess_block"),
+        to_span_selector: SpanSelector::new_equal_name("postprocess_ready_block"),
+        attribute_relations: vec![AttributeRelation {
+            from_attribute: "height".to_string(),
+            to_attribute: "height".to_string(),
+            relation: AttributeRelationOp::Equal,
+        }],
+        max_time_diff: Some(5.0), // 5 seconds
+        nodes_config: RelationNodesConfig::SameNode,
+        match_type: MatchType::MatchAll,
+        is_builtin: true,
+    }
+}
+
+pub fn postprocess_ready_block_to_produce_block_on_head_relation() -> Relation {
+    Relation {
+        id: make_uuid_from_seed("postprocess_ready_block -> produce_block_on_head"),
+        name: "postprocess_ready_block -> produce_block_on_head".to_string(),
+        description: "".to_string(),
+        from_span_selector: SpanSelector::new_equal_name("postprocess_ready_block"),
+        to_span_selector: SpanSelector::new_equal_name("produce_block_on_head"),
+        attribute_relations: vec![AttributeRelation {
+            from_attribute: "height".to_string(),
+            to_attribute: "height".to_string(),
+            relation: AttributeRelationOp::OneGreater,
+        }],
+        max_time_diff: Some(5.0), // 5 seconds
+        nodes_config: RelationNodesConfig::SameNode,
+        match_type: MatchType::MatchAll,
+        is_builtin: true,
+    }
+}
+
+pub fn postprocess_ready_block_to_next_preprocess_block_relation() -> Relation {
+    Relation {
+        id: make_uuid_from_seed("post-pre-process block"),
+        name: "postprocess_ready_block to next preprocess_block".to_string(),
+        description: "".to_string(),
+        from_span_selector: SpanSelector::new_equal_name("postprocess_ready_block"),
+        to_span_selector: SpanSelector::new_equal_name("preprocess_block"),
+        attribute_relations: vec![AttributeRelation {
+            from_attribute: "height".to_string(),
+            to_attribute: "height".to_string(),
+            relation: AttributeRelationOp::OneGreater,
+        }],
+        max_time_diff: Some(5.0), // 5 seconds
+        nodes_config: RelationNodesConfig::SameNode,
+        match_type: MatchType::MatchAll,
+        is_builtin: true,
+    }
+}
+
+pub fn preprocess_block_to_apply_new_chunk_relation() -> Relation {
+    Relation {
+        id: make_uuid_from_seed("preprocess_block -> apply_new_chunk"),
+        name: "preprocess_block -> apply_new_chunk".to_string(),
+        description: "".to_string(),
+        from_span_selector: SpanSelector::new_equal_name("preprocess_block"),
+        to_span_selector: SpanSelector {
+            span_name_condition: MatchCondition::equal_to("apply_new_chunk"),
+            node_name_condition: MatchCondition::any(),
+            attribute_conditions: vec![
+                (
+                    "apply_reason".to_string(),
+                    MatchCondition::equal_to("UpdateTrackedShard"),
+                ),
+                ("block_type".to_string(), MatchCondition::equal_to("Normal")),
+            ],
+        },
+        attribute_relations: vec![AttributeRelation {
+            from_attribute: "height".to_string(),
+            to_attribute: "height".to_string(),
+            relation: AttributeRelationOp::Equal,
+        }],
+        max_time_diff: Some(5.0), // 5 seconds
+        nodes_config: RelationNodesConfig::SameNode,
+        match_type: MatchType::MatchAll,
+        is_builtin: true,
+    }
+}
+
+pub fn apply_new_chunk_normal_to_postprocess_ready_block_relation() -> Relation {
+    Relation {
+        id: make_uuid_from_seed("apply_new_chunk(normal) -> postprocess_ready_block"),
+        name: "apply_new_chunk(normal) -> postprocess_ready_block".to_string(),
+        description: "".to_string(),
+        from_span_selector: SpanSelector {
+            span_name_condition: MatchCondition::equal_to("apply_new_chunk"),
+            node_name_condition: MatchCondition::any(),
+            attribute_conditions: vec![
+                (
+                    "apply_reason".to_string(),
+                    MatchCondition::equal_to("UpdateTrackedShard"),
+                ),
+                (
+                    "block_type".to_string(),
+                    MatchCondition::equal_to("Optimistic"),
+                ),
+            ],
+        },
+        to_span_selector: SpanSelector::new_equal_name("postprocess_ready_block"),
+        attribute_relations: vec![AttributeRelation {
+            from_attribute: "height".to_string(),
+            to_attribute: "height".to_string(),
+            relation: AttributeRelationOp::Equal,
+        }],
+        max_time_diff: Some(5.0), // 5 seconds
+        nodes_config: RelationNodesConfig::SameNode,
+        match_type: MatchType::MatchAll,
+        is_builtin: true,
+    }
+}
+
+pub fn apply_new_chunk_optimistic_to_postprocess_ready_block_relation() -> Relation {
+    Relation {
+        id: make_uuid_from_seed("apply_new_chunk(optimistic) -> postprocess_ready_block"),
+        name: "apply_new_chunk(optimistic) -> postprocess_ready_block".to_string(),
+        description: "".to_string(),
+        from_span_selector: SpanSelector {
+            span_name_condition: MatchCondition::equal_to("apply_new_chunk"),
+            node_name_condition: MatchCondition::any(),
+            attribute_conditions: vec![
+                (
+                    "apply_reason".to_string(),
+                    MatchCondition::equal_to("UpdateTrackedShard"),
+                ),
+                (
+                    "block_type".to_string(),
+                    MatchCondition::equal_to("Optimistic"),
+                ),
+            ],
+        },
+        to_span_selector: SpanSelector::new_equal_name("postprocess_ready_block"),
+        attribute_relations: vec![AttributeRelation {
+            from_attribute: "height".to_string(),
+            to_attribute: "height".to_string(),
+            relation: AttributeRelationOp::Equal,
+        }],
+        max_time_diff: Some(5.0), // 5 seconds
+        nodes_config: RelationNodesConfig::SameNode,
+        match_type: MatchType::MatchAll,
+        is_builtin: true,
+    }
+}
+
+pub fn postprocess_ready_block_to_produce_chunk_relation() -> Relation {
+    Relation {
+        id: make_uuid_from_seed("postprocess_ready_block -> produce_chunk"),
+        name: "postprocess_ready_block -> produce_chunk".to_string(),
+        description: "".to_string(),
+        from_span_selector: SpanSelector::new_equal_name("postprocess_ready_block"),
+        to_span_selector: SpanSelector::new_equal_name("produce_chunk"),
+        attribute_relations: vec![AttributeRelation {
+            from_attribute: "height".to_string(),
+            to_attribute: "height".to_string(),
+            relation: AttributeRelationOp::OneGreater,
+        }],
+        max_time_diff: Some(5.0), // 5 seconds
+        nodes_config: RelationNodesConfig::SameNode,
+        match_type: MatchType::MatchAll,
+        is_builtin: true,
+    }
+}
+
+pub fn produce_chunk_to_send_chunk_state_witness_relation() -> Relation {
+    Relation {
+        id: make_uuid_from_seed("produce_chunk -> send_chunk_state_witness"),
+        name: "produce_chunk -> send_chunk_state_witness".to_string(),
+        description: "".to_string(),
+        from_span_selector: SpanSelector::new_equal_name("produce_chunk"),
+        to_span_selector: SpanSelector::new_equal_name("send_chunk_state_witness"),
+        attribute_relations: vec![
+            AttributeRelation {
+                from_attribute: "height".to_string(),
+                to_attribute: "height".to_string(),
+                relation: AttributeRelationOp::Equal,
+            },
+            AttributeRelation {
+                from_attribute: "shard_id".to_string(),
+                to_attribute: "shard_id".to_string(),
+                relation: AttributeRelationOp::Equal,
+            },
+        ],
+        max_time_diff: Some(5.0), // 5 seconds
+        nodes_config: RelationNodesConfig::SameNode,
+        match_type: MatchType::MatchAll,
+        is_builtin: true,
+    }
+}
+
+pub fn send_chunk_state_witness_to_validate_chunk_state_witness_relation() -> Relation {
+    Relation {
+        id: make_uuid_from_seed("send-validate witness"),
+        name: "send_chunk_state_witness -> validate_chunk_state_witness".to_string(),
+        description: "".to_string(),
+        from_span_selector: SpanSelector::new_equal_name("send_chunk_state_witness"),
+        to_span_selector: SpanSelector::new_equal_name("validate_chunk_state_witness"),
+        attribute_relations: vec![
+            AttributeRelation {
+                from_attribute: "height".to_string(),
+                to_attribute: "height".to_string(),
+                relation: AttributeRelationOp::Equal,
+            },
+            AttributeRelation {
+                from_attribute: "shard_id".to_string(),
+                to_attribute: "shard_id".to_string(),
+                relation: AttributeRelationOp::Equal,
+            },
+        ],
+        max_time_diff: Some(5.0), // 5 seconds
+        nodes_config: RelationNodesConfig::AllNodes,
+        match_type: MatchType::MatchAll,
+        is_builtin: true,
+    }
+}
+
+pub fn validate_chunk_state_witness_to_send_chunk_endorsement_relation() -> Relation {
+    Relation {
+        id: make_uuid_from_seed("validate_chunk_state_witness -> send_chunk_endorsement"),
+        name: "validate_chunk_state_witness -> send_chunk_endorsement".to_string(),
+        description: "".to_string(),
+        from_span_selector: SpanSelector::new_equal_name("validate_chunk_state_witness"),
+        to_span_selector: SpanSelector::new_equal_name("send_chunk_endorsement"),
+        attribute_relations: vec![
+            AttributeRelation {
+                from_attribute: "height".to_string(),
+                to_attribute: "height".to_string(),
+                relation: AttributeRelationOp::Equal,
+            },
+            AttributeRelation {
+                from_attribute: "shard_id".to_string(),
+                to_attribute: "shard_id".to_string(),
+                relation: AttributeRelationOp::Equal,
+            },
+        ],
+        max_time_diff: Some(5.0), // 5 seconds
+        nodes_config: RelationNodesConfig::SameNode,
+        match_type: MatchType::MatchAll,
+        is_builtin: true,
+    }
+}
+
+pub fn send_chunk_endorsement_to_validate_chunk_endorsement_relation() -> Relation {
+    Relation {
+        id: make_uuid_from_seed("send-validate chunk endorsement"),
+        name: "send_chunk_endorsement -> validate_chunk_endorsement".to_string(),
+        description: "".to_string(),
+        from_span_selector: SpanSelector::new_equal_name("send_chunk_endorsement"),
+        to_span_selector: SpanSelector::new_equal_name("validate_chunk_endorsement"),
+        attribute_relations: vec![
+            AttributeRelation {
+                from_attribute: "height".to_string(),
+                to_attribute: "height".to_string(),
+                relation: AttributeRelationOp::Equal,
+            },
+            AttributeRelation {
+                from_attribute: "shard_id".to_string(),
+                to_attribute: "shard_id".to_string(),
+                relation: AttributeRelationOp::Equal,
+            },
+            AttributeRelation {
+                from_attribute: "validator".to_string(),
+                to_attribute: "validator".to_string(),
+                relation: AttributeRelationOp::Equal,
+            },
+        ],
+        max_time_diff: Some(5.0), // 5 seconds
+        nodes_config: RelationNodesConfig::AllNodes,
+        match_type: MatchType::MatchAll,
+        is_builtin: true,
+    }
+}
+pub fn validate_chunk_endorsement_to_produce_block_on_head_relation() -> Relation {
+    Relation {
+        id: make_uuid_from_seed("validate_chunk_endorsement -> produce_block_on_head"),
+        name: "validate_chunk_endorsement -> produce_block_on_head".to_string(),
+        description: "".to_string(),
+        from_span_selector: SpanSelector::new_equal_name("validate_chunk_endorsement"),
+        to_span_selector: SpanSelector::new_equal_name("produce_block_on_head"),
+        attribute_relations: vec![AttributeRelation {
+            from_attribute: "height".to_string(),
+            to_attribute: "height".to_string(),
+            relation: AttributeRelationOp::Equal,
+        }],
+        max_time_diff: Some(5.0), // 5 seconds
+        nodes_config: RelationNodesConfig::SameNode,
+        match_type: MatchType::MatchAll,
+        is_builtin: true,
+    }
+}
+
+pub fn postprocess_ready_block_to_produce_optimistic_block_on_head_relation() -> Relation {
+    Relation {
+        id: make_uuid_from_seed("postprocess_ready_block -> produce_optimistic_block_on_head"),
+        name: "postprocess_ready_block -> produce_optimistic_block_on_head".to_string(),
+        description: "".to_string(),
+        from_span_selector: SpanSelector::new_equal_name("postprocess_ready_block"),
+        to_span_selector: SpanSelector::new_equal_name("produce_optimistic_block_on_head"),
+        attribute_relations: vec![AttributeRelation {
+            from_attribute: "height".to_string(),
+            to_attribute: "height".to_string(),
+            relation: AttributeRelationOp::OneGreater,
+        }],
+        max_time_diff: Some(5.0), // 5 seconds
+        nodes_config: RelationNodesConfig::SameNode,
+        match_type: MatchType::MatchAll,
+        is_builtin: true,
+    }
+}
+
+pub fn produce_optimistic_block_on_head_to_process_optimistic_block_relation() -> Relation {
+    Relation {
+        id: make_uuid_from_seed("produce optimistic -> preprocess optimistic"),
+        name: "produce_optimistic_block_on_head -> process_optimistic_block".to_string(),
+        description: "".to_string(),
+        from_span_selector: SpanSelector::new_equal_name("produce_optimistic_block_on_head"),
+        to_span_selector: SpanSelector::new_equal_name("process_optimistic_block"),
+        attribute_relations: vec![AttributeRelation {
+            from_attribute: "height".to_string(),
+            to_attribute: "height".to_string(),
+            relation: AttributeRelationOp::Equal,
+        }],
+        max_time_diff: Some(5.0), // 5 seconds
+        nodes_config: RelationNodesConfig::AllNodes,
+        match_type: MatchType::MatchAll,
+        is_builtin: true,
+    }
+}
+
+pub fn process_optimistic_block_to_apply_new_chunk_optimistic_relation() -> Relation {
+    Relation {
+        id: make_uuid_from_seed("process_optimistic_block -> apply_new_chunk(optimistic)"),
+        name: "process_optimistic_block -> apply_new_chunk(optimistic)".to_string(),
+        description: "".to_string(),
+        from_span_selector: SpanSelector::new_equal_name("process_optimistic_block"),
+        to_span_selector: SpanSelector {
+            span_name_condition: MatchCondition::equal_to("apply_new_chunk"),
+            node_name_condition: MatchCondition::any(),
+            attribute_conditions: vec![
+                (
+                    "apply_reason".to_string(),
+                    MatchCondition::equal_to("UpdateTrackedShard"),
+                ),
+                (
+                    "block_type".to_string(),
+                    MatchCondition::equal_to("Optimistic"),
+                ),
+            ],
+        },
+        attribute_relations: vec![AttributeRelation {
+            from_attribute: "height".to_string(),
+            to_attribute: "height".to_string(),
+            relation: AttributeRelationOp::Equal,
+        }],
+        max_time_diff: Some(5.0), // 5 seconds
+        nodes_config: RelationNodesConfig::SameNode,
+        match_type: MatchType::MatchAll,
+        is_builtin: true,
+    }
+}
+
+pub fn builtin_relations() -> Vec<Relation> {
+    vec![
+        produce_block_on_head_to_preprocess_block_relation(),
+        preprocess_block_to_postprocess_ready_block_relation(),
+        postprocess_ready_block_to_produce_block_on_head_relation(),
+        postprocess_ready_block_to_next_preprocess_block_relation(),
+        preprocess_block_to_apply_new_chunk_relation(),
+        apply_new_chunk_normal_to_postprocess_ready_block_relation(),
+        apply_new_chunk_optimistic_to_postprocess_ready_block_relation(),
+        postprocess_ready_block_to_produce_chunk_relation(),
+        produce_chunk_to_send_chunk_state_witness_relation(),
+        send_chunk_state_witness_to_validate_chunk_state_witness_relation(),
+        validate_chunk_state_witness_to_send_chunk_endorsement_relation(),
+        send_chunk_endorsement_to_validate_chunk_endorsement_relation(),
+        validate_chunk_endorsement_to_produce_block_on_head_relation(),
+        postprocess_ready_block_to_produce_optimistic_block_on_head_relation(),
+        produce_optimistic_block_on_head_to_process_optimistic_block_relation(),
+        process_optimistic_block_to_apply_new_chunk_optimistic_relation(),
+    ]
+}

--- a/src/builtin_relations.rs
+++ b/src/builtin_relations.rs
@@ -122,10 +122,7 @@ pub fn apply_new_chunk_normal_to_postprocess_ready_block_relation() -> Relation 
                     "apply_reason".to_string(),
                     MatchCondition::equal_to("UpdateTrackedShard"),
                 ),
-                (
-                    "block_type".to_string(),
-                    MatchCondition::equal_to("Optimistic"),
-                ),
+                ("block_type".to_string(), MatchCondition::equal_to("Normal")),
             ],
         },
         to_span_selector: SpanSelector::new_equal_name("postprocess_ready_block"),

--- a/src/edit_modes.rs
+++ b/src/edit_modes.rs
@@ -361,57 +361,12 @@ impl EditDisplayModes {
             ui.text_edit_singleline(&mut self.current_span_rule.name);
         });
         self.draw_short_separator(ui);
-        ui.label("Span name condition");
-        Self::draw_edit_match_condition(
+        Self::draw_edit_span_selector(
+            &mut self.current_span_rule.selector,
             ui,
-            &mut self.current_span_rule.selector.span_name_condition,
-            "span name condition",
+            self.max_width,
+            "span rule selector",
         );
-        self.draw_short_separator(ui);
-        ui.label("Node name condition");
-        Self::draw_edit_match_condition(
-            ui,
-            &mut self.current_span_rule.selector.node_name_condition,
-            "node name condition",
-        );
-        self.draw_short_separator(ui);
-        ui.label("Attribute Conditions");
-        let mut attribute_condition_to_remove = None;
-        for (i, attr_condition) in &mut self
-            .current_span_rule
-            .selector
-            .attribute_conditions
-            .iter_mut()
-            .enumerate()
-        {
-            ui.horizontal(|ui| {
-                ui.label("Attribute Name:");
-                ui.text_edit_singleline(&mut attr_condition.0);
-                Self::draw_edit_match_condition(
-                    ui,
-                    &mut attr_condition.1,
-                    format!("attribute condition {}", i).as_str(),
-                );
-                if ui.button("Remove").clicked() {
-                    attribute_condition_to_remove = Some(i);
-                }
-            });
-        }
-        if let Some(idx) = attribute_condition_to_remove {
-            self.current_span_rule
-                .selector
-                .attribute_conditions
-                .remove(idx);
-        }
-        if ui.button("New Attribute Condition").clicked() {
-            self.current_span_rule.selector.attribute_conditions.push((
-                "<attribute name>".to_string(),
-                MatchCondition {
-                    operator: MatchOperator::EqualTo,
-                    value: "val".to_string(),
-                },
-            ));
-        }
         self.draw_short_separator(ui);
         ui.label("Decision");
         ui.horizontal(|ui| {
@@ -510,6 +465,62 @@ impl EditDisplayModes {
                     ui.text_edit_singleline(&mut condition.value);
                 });
             }
+        }
+    }
+
+    pub fn draw_edit_span_selector(
+        selector: &mut SpanSelector,
+        ui: &mut Ui,
+        max_width: f32,
+        ui_seed: &str,
+    ) {
+        let draw_short_separator = |ui: &mut Ui| {
+            ui.set_max_width(10.0);
+            ui.separator();
+            ui.set_max_width(max_width);
+        };
+
+        ui.label("Span name condition");
+        Self::draw_edit_match_condition(
+            ui,
+            &mut selector.span_name_condition,
+            &format!("span name condition {ui_seed}"),
+        );
+        draw_short_separator(ui);
+        ui.label("Node name condition");
+        Self::draw_edit_match_condition(
+            ui,
+            &mut selector.node_name_condition,
+            &format!("node name condition {ui_seed}"),
+        );
+        draw_short_separator(ui);
+        ui.label("Attribute Conditions");
+        let mut attribute_condition_to_remove = None;
+        for (i, attr_condition) in &mut selector.attribute_conditions.iter_mut().enumerate() {
+            ui.horizontal(|ui| {
+                ui.label("Attribute Name:");
+                ui.text_edit_singleline(&mut attr_condition.0);
+                Self::draw_edit_match_condition(
+                    ui,
+                    &mut attr_condition.1,
+                    format!("attribute condition {} {}", ui_seed, i).as_str(),
+                );
+                if ui.button("Remove").clicked() {
+                    attribute_condition_to_remove = Some(i);
+                }
+            });
+        }
+        if let Some(idx) = attribute_condition_to_remove {
+            selector.attribute_conditions.remove(idx);
+        }
+        if ui.button("New Attribute Condition").clicked() {
+            selector.attribute_conditions.push((
+                "<attribute name>".to_string(),
+                MatchCondition {
+                    operator: MatchOperator::EqualTo,
+                    value: "val".to_string(),
+                },
+            ));
         }
     }
 }

--- a/src/edit_relations.rs
+++ b/src/edit_relations.rs
@@ -146,6 +146,7 @@ impl EditRelations {
             }
             if ui.button("Clone Relation").clicked() {
                 let mut new_relation = self.relations[self.selected_relation_idx].clone();
+                new_relation.id = Uuid::new_v4();
                 new_relation.name = format!("{} Clone", new_relation.name);
                 new_relation.is_builtin = false;
                 self.relations.push(new_relation);

--- a/src/edit_relations.rs
+++ b/src/edit_relations.rs
@@ -2,10 +2,11 @@ use eframe::egui::{self, Button, ComboBox, Modal, ScrollArea, Ui, Vec2, Widget};
 use std::collections::HashMap;
 use uuid::Uuid;
 
-use crate::edit_modes::{AddingOrEditing, HIGHLIGHT_COLOR};
+use crate::edit_modes::{AddingOrEditing, EditDisplayModes, HIGHLIGHT_COLOR};
 use crate::relation::{
     AttributeRelation, AttributeRelationOp, MatchType, Relation, RelationNodesConfig, RelationView,
 };
+use crate::structured_modes::SpanSelector;
 
 #[derive(Clone, Debug)]
 pub struct EditRelations {
@@ -217,21 +218,33 @@ impl EditRelations {
     }
 
     fn draw_editing_relation(&mut self, ui: &mut Ui, _ctx: &egui::Context) {
-        ui.label("Editing Relation");
+        ui.heading("Editing Relation");
         self.draw_short_separator(ui);
         ui.horizontal(|ui| {
             ui.label("Relation name:");
             ui.text_edit_singleline(&mut self.current_relation.name);
         });
-        ui.horizontal(|ui| {
-            ui.label("From Span Name:");
-            ui.text_edit_singleline(&mut self.current_relation.from_span_name);
-        });
-        ui.horizontal(|ui| {
-            ui.label("To Span Name:");
-            ui.text_edit_singleline(&mut self.current_relation.to_span_name);
-        });
-        ui.label("Attribute Relations");
+        // TODO - description
+        self.draw_short_separator(ui);
+        ui.strong("From span selector");
+        EditDisplayModes::draw_edit_span_selector(
+            &mut self.current_relation.from_span_selector,
+            ui,
+            self.max_width,
+            "from span selector",
+        );
+        ui.add_space(20.0);
+        self.draw_short_separator(ui);
+        ui.strong("To span selector");
+        EditDisplayModes::draw_edit_span_selector(
+            &mut self.current_relation.to_span_selector,
+            ui,
+            self.max_width,
+            "to span selector",
+        );
+        ui.add_space(20.0);
+        self.draw_short_separator(ui);
+        ui.strong("Attribute Relations");
         let mut attribute_relation_to_remove = None;
         for (i, attr_condition) in &mut self
             .current_relation
@@ -281,6 +294,7 @@ impl EditRelations {
         }
 
         self.draw_short_separator(ui);
+        ui.strong("Other options");
         ui.horizontal(|ui| {
             ui.label("Max time difference (seconds):");
             ui.text_edit_singleline(&mut self.time_difference_string);
@@ -371,8 +385,9 @@ impl EditRelations {
         Relation {
             id: Uuid::new_v4(),
             name: "New relation".to_string(),
-            from_span_name: "from span".to_string(),
-            to_span_name: "to span".to_string(),
+            description: String::new(),
+            from_span_selector: SpanSelector::new_equal_name("from span"),
+            to_span_selector: SpanSelector::new_equal_name("to span"),
             attribute_relations: vec![],
             max_time_diff: Some(10.0),
             nodes_config: RelationNodesConfig::AllNodes,

--- a/src/legacy.rs
+++ b/src/legacy.rs
@@ -1,0 +1,39 @@
+//! Old code that is being kept for backwards compatibility.
+
+use uuid::Uuid;
+
+use crate::relation::{AttributeRelation, MatchType, Relation, RelationNodesConfig};
+use crate::structured_modes::SpanSelector;
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct RelationV0 {
+    pub id: Uuid,
+
+    pub name: String,
+    pub from_span_name: String,
+    pub to_span_name: String,
+    pub attribute_relations: Vec<AttributeRelation>,
+    pub max_time_diff: Option<f64>,
+
+    pub nodes_config: RelationNodesConfig,
+    pub match_type: MatchType,
+
+    pub is_builtin: bool,
+}
+
+impl From<RelationV0> for Relation {
+    fn from(relation: RelationV0) -> Self {
+        Relation {
+            id: relation.id,
+            name: relation.name,
+            description: String::new(),
+            from_span_selector: SpanSelector::new_equal_name(&relation.from_span_name),
+            to_span_selector: SpanSelector::new_equal_name(&relation.to_span_name),
+            attribute_relations: relation.attribute_relations,
+            max_time_diff: relation.max_time_diff,
+            nodes_config: relation.nodes_config,
+            match_type: relation.match_type,
+            is_builtin: relation.is_builtin,
+        }
+    }
+}

--- a/src/legacy.rs
+++ b/src/legacy.rs
@@ -33,6 +33,7 @@ impl From<RelationV0> for Relation {
             max_time_diff: relation.max_time_diff,
             nodes_config: relation.nodes_config,
             match_type: relation.match_type,
+            min_time_diff: 0.0,
             is_builtin: relation.is_builtin,
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,10 +17,7 @@ use eframe::epaint::PathShape;
 use modes::structured_mode_transformation;
 use node_filter::{EditNodeFilters, NodeFilter};
 use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
-use relation::{
-    builtin_relation_views, builtin_relations, find_relations, Relation, RelationInstance,
-    RelationView,
-};
+use relation::{builtin_relation_views, find_relations, Relation, RelationInstance, RelationView};
 use structured_modes::StructuredMode;
 use task_timer::TaskTimer;
 use types::{
@@ -31,9 +28,11 @@ use types::{
 mod analyze_dependency;
 mod analyze_span;
 mod analyze_utils;
+mod builtin_relations;
 mod colors;
 mod edit_modes;
 mod edit_relations;
+mod legacy;
 mod modes;
 mod node_filter;
 mod persistent;
@@ -250,7 +249,7 @@ impl Default for App {
             hovered_arrow_key: None,
             cached_produce_block_starts: None,
             cached_node_spans: None,
-            defined_relations: builtin_relations(),
+            defined_relations: builtin_relations::builtin_relations(),
             relation_views: builtin_relation_views(),
             current_relation_view_index: 0,
             active_relations: vec![],

--- a/src/relation.rs
+++ b/src/relation.rs
@@ -30,7 +30,7 @@ pub struct Relation {
     pub match_type: MatchType,
 
     /// Minimum distance between the end of the "from" span and the start of the "to" span.
-    /// to_span.end_time - from_span.start_time >= min_time_diff
+    /// to_span.start_time - from_span.end_time >= min_time_diff
     /// Setting it to a negative value allows relations to match even if the "to" span starts before the "from" span ends.
     pub min_time_diff: f64,
 

--- a/src/relation.rs
+++ b/src/relation.rs
@@ -190,6 +190,7 @@ pub fn find_relations(
             .filter(|name| relation.to_span_selector.span_name_condition.matches(name))
             .collect::<Vec<_>>();
 
+        let mut found_relation_instances = 0;
         for from_span_name in &matching_from_span_names {
             let Some(from_spans) = spans_by_name.get(from_span_name.as_str()) else {
                 continue;
@@ -227,6 +228,7 @@ pub fn find_relations(
                             .borrow_mut()
                             .push(instance.clone());
                         res.push(instance);
+                        found_relation_instances += 1;
 
                         match relation.match_type {
                             MatchType::MatchAll => {
@@ -242,6 +244,10 @@ pub fn find_relations(
                 }
             }
         }
+        println!(
+            "Found {} instances of relation '{}'",
+            found_relation_instances, relation.name
+        );
     }
 
     task_timer.stop();

--- a/src/relation.rs
+++ b/src/relation.rs
@@ -4,6 +4,8 @@ use std::rc::{Rc, Weak};
 use sha2::Digest;
 use uuid::Uuid;
 
+use crate::builtin_relations;
+use crate::structured_modes::SpanSelector;
 use crate::task_timer::TaskTimer;
 use crate::types::{value_to_text, Span};
 
@@ -18,8 +20,9 @@ pub struct Relation {
     pub id: Uuid,
 
     pub name: String,
-    pub from_span_name: String,
-    pub to_span_name: String,
+    pub description: String,
+    pub from_span_selector: SpanSelector,
+    pub to_span_selector: SpanSelector,
     pub attribute_relations: Vec<AttributeRelation>,
     pub max_time_diff: Option<f64>,
 
@@ -57,10 +60,10 @@ pub enum MatchType {
 
 impl Relation {
     pub fn matches(&self, from_span: &Span, to_span: &Span) -> bool {
-        if from_span.original_name() != self.from_span_name {
+        if !self.from_span_selector.matches(from_span) {
             return false;
         }
-        if to_span.original_name() != self.to_span_name {
+        if !self.to_span_selector.matches(to_span) {
             return false;
         }
 
@@ -173,50 +176,68 @@ pub fn find_relations(
         };
         let relation = Rc::new(relation.clone());
 
-        let Some(from_spans) = spans_by_name.get(&relation.from_span_name) else {
-            continue;
-        };
-        let Some(to_spans) = spans_by_name.get(&relation.to_span_name) else {
-            continue;
-        };
+        let matching_from_span_names = spans_by_name
+            .keys()
+            .filter(|name| {
+                relation
+                    .from_span_selector
+                    .span_name_condition
+                    .matches(name)
+            })
+            .collect::<Vec<_>>();
+        let matching_to_span_names = spans_by_name
+            .keys()
+            .filter(|name| relation.to_span_selector.span_name_condition.matches(name))
+            .collect::<Vec<_>>();
 
-        for from_span in from_spans {
-            let first_to_span_index = find_first_span_after(to_spans, from_span.end_time);
-            for to_span in &to_spans[first_to_span_index..] {
-                if let Some(max_time_diff) = relation.max_time_diff {
-                    if to_span.start_time - from_span.start_time > max_time_diff {
-                        break;
-                    }
-                }
-
-                if !relation.matches(from_span, to_span) {
+        for from_span_name in &matching_from_span_names {
+            let Some(from_spans) = spans_by_name.get(from_span_name.as_str()) else {
+                continue;
+            };
+            for to_span_name in &matching_to_span_names {
+                let Some(to_spans) = spans_by_name.get(to_span_name.as_str()) else {
                     continue;
-                }
-
-                let instance = RelationInstance {
-                    from_span: Rc::<Span>::downgrade(from_span),
-                    to_span: Rc::<Span>::downgrade(to_span),
-                    relation: relation.clone(),
                 };
 
-                from_span
-                    .outgoing_relations
-                    .borrow_mut()
-                    .push(instance.clone());
-                to_span
-                    .incoming_relations
-                    .borrow_mut()
-                    .push(instance.clone());
-                res.push(instance);
+                for from_span in from_spans {
+                    let first_to_span_index = find_first_span_after(to_spans, from_span.end_time);
+                    for to_span in &to_spans[first_to_span_index..] {
+                        if let Some(max_time_diff) = relation.max_time_diff {
+                            if to_span.start_time - from_span.start_time > max_time_diff {
+                                break;
+                            }
+                        }
 
-                match relation.match_type {
-                    MatchType::MatchAll => {
-                        // For MatchAll, we continue to find more matches
-                        continue;
-                    }
-                    MatchType::MatchClosest => {
-                        // For MatchClosest, we break after the first match
-                        break;
+                        if !relation.matches(from_span, to_span) {
+                            continue;
+                        }
+
+                        let instance = RelationInstance {
+                            from_span: Rc::<Span>::downgrade(from_span),
+                            to_span: Rc::<Span>::downgrade(to_span),
+                            relation: relation.clone(),
+                        };
+
+                        from_span
+                            .outgoing_relations
+                            .borrow_mut()
+                            .push(instance.clone());
+                        to_span
+                            .incoming_relations
+                            .borrow_mut()
+                            .push(instance.clone());
+                        res.push(instance);
+
+                        match relation.match_type {
+                            MatchType::MatchAll => {
+                                // For MatchAll, we continue to find more matches
+                                continue;
+                            }
+                            MatchType::MatchClosest => {
+                                // For MatchClosest, we break after the first match
+                                break;
+                            }
+                        }
                     }
                 }
             }
@@ -247,87 +268,6 @@ fn find_first_span_after(spans: &[Rc<Span>], start_time: f64) -> usize {
         .unwrap_or(spans.len())
 }
 
-fn pre_post_process_block_relation() -> Relation {
-    Relation {
-        id: make_uuid_from_seed("pre-post-process block"),
-        name: "pre-post-process block".to_string(),
-        from_span_name: "preprocess_block".to_string(),
-        to_span_name: "postprocess_ready_block".to_string(),
-        attribute_relations: vec![AttributeRelation {
-            from_attribute: "height".to_string(),
-            to_attribute: "height".to_string(),
-            relation: AttributeRelationOp::Equal,
-        }],
-        max_time_diff: Some(5.0), // 5 seconds
-        nodes_config: RelationNodesConfig::SameNode,
-        match_type: MatchType::MatchClosest,
-        is_builtin: true,
-    }
-}
-
-fn send_receive_witness_relation() -> Relation {
-    Relation {
-        id: make_uuid_from_seed("send-validate witness"),
-        name: "send-receive witness".to_string(),
-        from_span_name: "send_chunk_state_witness".to_string(),
-        to_span_name: "validate_chunk_state_witness".to_string(),
-        attribute_relations: vec![
-            AttributeRelation {
-                from_attribute: "height".to_string(),
-                to_attribute: "height".to_string(),
-                relation: AttributeRelationOp::Equal,
-            },
-            AttributeRelation {
-                from_attribute: "shard_id".to_string(),
-                to_attribute: "shard_id".to_string(),
-                relation: AttributeRelationOp::Equal,
-            },
-        ],
-        max_time_diff: Some(5.0), // 5 seconds
-        nodes_config: RelationNodesConfig::AllNodes,
-        match_type: MatchType::MatchAll,
-        is_builtin: true,
-    }
-}
-
-fn send_validate_chunk_endorsement() -> Relation {
-    Relation {
-        id: make_uuid_from_seed("send-validate chunk endorsement"),
-        name: "send-validate chunk endorsement".to_string(),
-        from_span_name: "send_chunk_endorsement".to_string(),
-        to_span_name: "validate_chunk_endorsement".to_string(),
-        attribute_relations: vec![
-            AttributeRelation {
-                from_attribute: "height".to_string(),
-                to_attribute: "height".to_string(),
-                relation: AttributeRelationOp::Equal,
-            },
-            AttributeRelation {
-                from_attribute: "shard_id".to_string(),
-                to_attribute: "shard_id".to_string(),
-                relation: AttributeRelationOp::Equal,
-            },
-            AttributeRelation {
-                from_attribute: "validator".to_string(),
-                to_attribute: "validator".to_string(),
-                relation: AttributeRelationOp::Equal,
-            },
-        ],
-        max_time_diff: Some(5.0), // 5 seconds
-        nodes_config: RelationNodesConfig::AllNodes,
-        match_type: MatchType::MatchAll,
-        is_builtin: true,
-    }
-}
-
-pub fn builtin_relations() -> Vec<Relation> {
-    vec![
-        pre_post_process_block_relation(),
-        send_receive_witness_relation(),
-        send_validate_chunk_endorsement(),
-    ]
-}
-
 pub fn builtin_relation_views() -> Vec<RelationView> {
     vec![
         RelationView {
@@ -337,22 +277,47 @@ pub fn builtin_relation_views() -> Vec<RelationView> {
         },
         RelationView {
             name: "Pre-Post Process Block".to_string(),
-            enabled_relations: vec![pre_post_process_block_relation().id],
+            enabled_relations: vec![
+                crate::builtin_relations::preprocess_block_to_postprocess_ready_block_relation().id,
+            ],
             is_builtin: true,
         },
         RelationView {
             name: "Send-Receive Witness".to_string(),
-            enabled_relations: vec![send_receive_witness_relation().id],
+            enabled_relations: vec![builtin_relations::send_chunk_state_witness_to_validate_chunk_state_witness_relation().id],
             is_builtin: true,
         },
         RelationView {
             name: "Send-Validate Chunk Endorsement".to_string(),
-            enabled_relations: vec![send_validate_chunk_endorsement().id],
+            enabled_relations: vec![builtin_relations::send_chunk_endorsement_to_validate_chunk_endorsement_relation().id],
+            is_builtin: true,
+        },
+        RelationView {
+            name: "Block production without witness and endorsement distribution".to_string(),
+            enabled_relations: vec![
+                builtin_relations::produce_block_on_head_to_preprocess_block_relation().id,
+                builtin_relations::preprocess_block_to_postprocess_ready_block_relation().id,
+                builtin_relations::postprocess_ready_block_to_produce_block_on_head_relation().id,
+                builtin_relations::postprocess_ready_block_to_next_preprocess_block_relation().id,
+                builtin_relations::preprocess_block_to_apply_new_chunk_relation().id,
+                builtin_relations::apply_new_chunk_normal_to_postprocess_ready_block_relation().id,
+                builtin_relations::apply_new_chunk_optimistic_to_postprocess_ready_block_relation().id,
+                builtin_relations::postprocess_ready_block_to_produce_chunk_relation().id,
+                builtin_relations::produce_chunk_to_send_chunk_state_witness_relation().id,
+                builtin_relations::validate_chunk_state_witness_to_send_chunk_endorsement_relation().id,
+                builtin_relations::validate_chunk_endorsement_to_produce_block_on_head_relation().id,
+                builtin_relations::postprocess_ready_block_to_produce_optimistic_block_on_head_relation().id,
+                builtin_relations::produce_optimistic_block_on_head_to_process_optimistic_block_relation().id,
+                builtin_relations::process_optimistic_block_to_apply_new_chunk_optimistic_relation().id,
+            ],
             is_builtin: true,
         },
         RelationView {
             name: "All builtin Relations".to_string(),
-            enabled_relations: builtin_relations().iter().map(|r| r.id).collect(),
+            enabled_relations: builtin_relations::builtin_relations()
+                .iter()
+                .map(|r| r.id)
+                .collect(),
             is_builtin: true,
         },
     ]

--- a/src/relation.rs
+++ b/src/relation.rs
@@ -29,6 +29,11 @@ pub struct Relation {
     pub nodes_config: RelationNodesConfig,
     pub match_type: MatchType,
 
+    /// Minimum distance between the end of the "from" span and the start of the "to" span.
+    /// to_span.end_time - from_span.start_time >= min_time_diff
+    /// Setting it to a negative value allows relations to match even if the "to" span starts before the "from" span ends.
+    pub min_time_diff: f64,
+
     pub is_builtin: bool,
 }
 
@@ -201,7 +206,10 @@ pub fn find_relations(
                 };
 
                 for from_span in from_spans {
-                    let first_to_span_index = find_first_span_after(to_spans, from_span.end_time);
+                    let first_to_span_index = find_first_span_after(
+                        to_spans,
+                        from_span.end_time + relation.min_time_diff,
+                    );
                     for to_span in &to_spans[first_to_span_index..] {
                         if let Some(max_time_diff) = relation.max_time_diff {
                             if to_span.start_time - from_span.start_time > max_time_diff {


### PR DESCRIPTION
* Add a lot of builtin relations which allow to show dependencies between block production spans.
* Make `Relation` use `SpanSelector` to select spans. Previous way of doing things (span name equal to something) wasn't expressive enough - I wanted to also add conditions for span attributes.
* Add a `description` field to Relation. Unused for now, but will be used in the future
* Implement a migration from the old Relation format to the new one. Users should be able to upgrade traviz seamlessly, persistent data will be converted to the new format automatically
* Add "Block production without VCE" display mode - VCEs are really noisy, I usually filter them out when viewing things

![image](https://github.com/user-attachments/assets/4bed7c0a-7346-416d-be92-1adbff33a6fd)

(some relations need https://github.com/near/nearcore/pull/13658 to function properly)