### PR TITLE
(analyze_dependency) Add variable matching attributes on numeric values

### DIFF
--- a/tests/test_helpers.rs
+++ b/tests/test_helpers.rs
@@ -172,6 +172,16 @@ impl SpanConfig {
     pub fn with_string_attr(self, key: &str, value: &str) -> Self {
         self.with_attr(key, string_attr(value))
     }
+
+    /// Add an integer attribute
+    pub fn with_int_attr(self, key: &str, value: i64) -> Self {
+        self.with_attr(key, int_attr(value))
+    }
+
+    /// Add a double attribute
+    pub fn with_double_attr(self, key: &str, value: f64) -> Self {
+        self.with_attr(key, double_attr(value))
+    }
 }
 
 /// Builder for creating comprehensive test scenarios


### PR DESCRIPTION
In a nutshell, this PR enables the user to run analysis of the kind:

`produce_block_on_head -> send_chunk_state_witness`
`linking by: height=+1`

In other words only `produce_block_on_head[H=100]` will match on `send_chunk_state_witness[H=101]`
