### PR TITLE
Add critical path built-in mode and grouping of spans

### DIFF
--- a/src/analyze_dependency.rs
+++ b/src/analyze_dependency.rs
@@ -1246,11 +1246,11 @@ impl AnalyzeDependencyModal {
         );
 
         if source_spans.is_empty() {
-            return Err(format!("No spans found with name \'{}\'", source_name));
+            return Err(format!("No spans found with name \'{source_name}\'"));
         }
 
         if target_spans.is_empty() {
-            return Err(format!("No spans found with name \'{}\'", target_name));
+            return Err(format!("No spans found with name \'{target_name}\'"));
         }
 
         // Determine expected_group_keys_set if grouping is active
@@ -1641,7 +1641,7 @@ impl AnalyzeDependencyModal {
                                                         if let Some(link) = &node_result.min_delay_link {
                                                             self.show_link_details_popup = Some(LinkDetailsPopupInfo {
                                                                 link: link.clone(),
-                                                                title: format!("Minimum Delay Link Details ({})", node_name),
+                                                                title: format!("Minimum Delay Link Details ({node_name})"),
                                                                 node_name: node_name.clone(),
                                                                 group_by_attribute_name: result.group_by_attribute.clone(),
                                                                 linking_attribute_name: result.linking_attribute.clone(),
@@ -1656,7 +1656,7 @@ impl AnalyzeDependencyModal {
                                                         if let Some(link) = &node_result.max_delay_link {
                                                             self.show_link_details_popup = Some(LinkDetailsPopupInfo {
                                                                 link: link.clone(),
-                                                                title: format!("Maximum Delay Link Details ({})", node_name),
+                                                                title: format!("Maximum Delay Link Details ({node_name})"),
                                                                 node_name: node_name.clone(),
                                                                 group_by_attribute_name: result.group_by_attribute.clone(),
                                                                 linking_attribute_name: result.linking_attribute.clone(),
@@ -1905,14 +1905,14 @@ impl AnalyzeDependencyModal {
                         cardinality = Some(match value {
                             "N-to-1" => AnalysisCardinality::NToOne,
                             "1-to-N" => AnalysisCardinality::OneToN,
-                            _ => return Err(format!("Unknown cardinality: {}", value)),
+                            _ => return Err(format!("Unknown cardinality: {value}")),
                         });
                     }
                     "threshold:" => {
                         threshold = Some(
                             value
                                 .parse::<usize>()
-                                .map_err(|_| format!("Invalid threshold: {}", value))?,
+                                .map_err(|_| format!("Invalid threshold: {value}"))?,
                         );
                     }
                     "linking by:" => {
@@ -1933,14 +1933,14 @@ impl AnalyzeDependencyModal {
                         scope = Some(match value {
                             "self" => SourceScope::SameNode,
                             "all nodes" => SourceScope::AllNodes,
-                            _ => return Err(format!("Unknown scope: {}", value)),
+                            _ => return Err(format!("Unknown scope: {value}")),
                         });
                     }
                     "timing:" => {
                         timing = Some(match value {
                             "Earliest First" => SourceTimingStrategy::EarliestFirst,
                             "Latest First" => SourceTimingStrategy::LatestFirst,
-                            _ => return Err(format!("Unknown timing strategy: {}", value)),
+                            _ => return Err(format!("Unknown timing strategy: {value}")),
                         });
                     }
                     "group aggregation:" => {
@@ -1950,10 +1950,7 @@ impl AnalyzeDependencyModal {
                                 GroupAggregationStrategy::FirstCompletedGroup
                             }
                             _ => {
-                                return Err(format!(
-                                    "Unknown group aggregation strategy: {}",
-                                    value
-                                ))
+                                return Err(format!("Unknown group aggregation strategy: {value}"))
                             }
                         });
                     }
@@ -2026,7 +2023,7 @@ impl AnalyzeDependencyModal {
                 ui_input_row.vertical(|ui_button_col| {
                     if ui_button_col.button("Parse, Fill and Analyze").clicked() {
                         if let Err(err) = self.parse_and_fill_from_description(&self.description_input.clone()) {
-                            self.error_message = Some(format!("Parse error: {}", err));
+                            self.error_message = Some(format!("Parse error: {err}"));
                         } else {
                             // Clear parse errors but keep other error messages
                             if let Some(ref msg) = self.error_message {
@@ -2140,7 +2137,7 @@ fn draw_link_visualization_ui_impl(ui: &mut Ui, details: &LinkDetailsPopupInfo) 
                                 ui.strong("Time to Target: ");
                                 let ttt_label_response = ui.monospace(time_to_target_display);
                                 ttt_label_response
-                                    .on_hover_text(format!("End: {}", end_timestamp_str));
+                                    .on_hover_text(format!("End: {end_timestamp_str}"));
 
                                 ui.strong(" Node: ");
                                 ui.monospace(&s_span.node.name);
@@ -2168,7 +2165,7 @@ fn draw_link_visualization_ui_impl(ui: &mut Ui, details: &LinkDetailsPopupInfo) 
 
                         ui.strong("Time to Target: ");
                         let ttt_label_response = ui.monospace(time_to_target_display);
-                        ttt_label_response.on_hover_text(format!("End: {}", end_timestamp_str));
+                        ttt_label_response.on_hover_text(format!("End: {end_timestamp_str}"));
 
                         ui.strong(" Node: ");
                         ui.monospace(&s_span.node.name);

--- a/src/analyze_span.rs
+++ b/src/analyze_span.rs
@@ -221,7 +221,7 @@ impl AnalyzeSpanModal {
 
         if matching_spans.is_empty() {
             self.analysis_summary_message =
-                Some(format!("No spans found with name '{}'", target_name));
+                Some(format!("No spans found with name '{target_name}'"));
             // Clear previous results
             self.detailed_span_analysis = None;
             return;

--- a/src/colors.rs
+++ b/src/colors.rs
@@ -30,6 +30,7 @@ pub const VERY_LIGHT_YELLOW: Color32 = Color32::from_rgb(255, 255, 220);
 pub const DARK_YELLOW: Color32 = Color32::from_rgb(242, 176, 34);
 pub const MILD_RED: Color32 = Color32::from_rgb(220, 50, 50);
 pub const INTENSE_RED: Color32 = Color32::from_rgb(255, 51, 0);
+pub const INTENSE_GREEN: Color32 = Color32::from_rgb(50, 200, 50);
 
 pub fn transparent_yellow() -> Color32 {
     Color32::from_rgba_unmultiplied(242, 176, 34, 1)

--- a/src/edit_modes.rs
+++ b/src/edit_modes.rs
@@ -508,7 +508,7 @@ impl EditDisplayModes {
                 Self::draw_edit_match_condition(
                     ui,
                     &mut attr_condition.1,
-                    format!("attribute condition {} {}", ui_seed, i).as_str(),
+                    format!("attribute condition {ui_seed} {i}").as_str(),
                 );
                 if ui.button("Remove").clicked() {
                     attribute_condition_to_remove = Some(i);

--- a/src/edit_modes.rs
+++ b/src/edit_modes.rs
@@ -117,6 +117,7 @@ impl EditDisplayModes {
                 replace_name: String::new(),
                 add_height_to_name: true,
                 add_shard_id_to_name: true,
+                group: false,
             },
         }
     }
@@ -417,6 +418,10 @@ impl EditDisplayModes {
         ui.checkbox(
             &mut self.current_span_rule.decision.add_shard_id_to_name,
             "Add Shard ID to Name",
+        );
+        ui.checkbox(
+            &mut self.current_span_rule.decision.group,
+            "Group spans with same Name and Height",
         );
         self.draw_short_separator(ui);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -256,9 +256,9 @@ impl Default for App {
 
         // If a file path is provided as the first argument, try to load it.
         if let Some(first_arg) = std::env::args().nth(1) {
-            println!("Trying to open file: {}", first_arg);
+            println!("Trying to open file: {first_arg}");
             if let Err(err) = res.load_file(&PathBuf::from(first_arg)) {
-                println!("Error loading file: {}", err);
+                println!("Error loading file: {err}");
             } else {
                 println!("File loaded successfully.");
             }
@@ -320,7 +320,7 @@ impl eframe::App for App {
                         self.current_display_mode_index = 0;
                     }
                     if let Err(e) = self.apply_current_mode() {
-                        println!("Failed to apply display mode: {}", e);
+                        println!("Failed to apply display mode: {e}");
                     }
                 }
 
@@ -401,10 +401,10 @@ impl App {
                 // TODO - fix file picker
 
                 if let Some(path) = rfd::FileDialog::new().pick_file() {
-                    println!("Loading file: {:?}...", path);
+                    println!("Loading file: {path:?}...");
                     match self.load_file(&path) {
                         Ok(()) => println!("Successfully loaded file."),
-                        Err(e) => println!("Error loading file: {}", e),
+                        Err(e) => println!("Error loading file: {e}"),
                     }
                 }
             }
@@ -415,7 +415,7 @@ impl App {
                 .get(self.current_display_mode_index)
                 .map_or("Deleted".to_string(), |mode| mode.name.clone());
             ComboBox::new("mode chooser", "")
-                .selected_text(format!("Display mode: {}", current_mode_name))
+                .selected_text(format!("Display mode: {current_mode_name}"))
                 .show_ui(ui, |ui| {
                     for (i, mode) in self.display_modes.iter().enumerate() {
                         ui.selectable_value(
@@ -427,7 +427,7 @@ impl App {
                 });
             if previous_display_mode_index != self.current_display_mode_index {
                 if let Err(e) = self.apply_current_mode() {
-                    println!("Failed to apply display mode: {}", e);
+                    println!("Failed to apply display mode: {e}");
                     // Go back to the previous mode
                     self.current_display_mode_index = previous_display_mode_index;
                 }
@@ -438,7 +438,7 @@ impl App {
                 .get(self.current_node_filter_index)
                 .map_or("Deleted".to_string(), |filter| filter.name.clone());
             ComboBox::new("node filter chooser", "")
-                .selected_text(format!("Node filter: {}", current_node_filter_name))
+                .selected_text(format!("Node filter: {current_node_filter_name}"))
                 .show_ui(ui, |ui| {
                     for (i, filter) in self.node_filters.iter().enumerate() {
                         ui.selectable_value(
@@ -455,7 +455,7 @@ impl App {
                 .get(self.current_relation_view_index)
                 .map_or("Deleted".to_string(), |view| view.name.clone());
             ComboBox::new("relation view chooser", "")
-                .selected_text(format!("Relation view: {}", current_relations_view_name))
+                .selected_text(format!("Relation view: {current_relations_view_name}"))
                 .show_ui(ui, |ui| {
                     for (i, view) in self.relation_views.iter().enumerate() {
                         ui.selectable_value(
@@ -1521,7 +1521,7 @@ impl App {
             {
                 ui.label("Individual Spans:");
                 for line in spans_info.lines() {
-                    ui.label(format!("- {}", line));
+                    ui.label(format!("- {line}"));
                 }
             } else {
                 ui.label("(No individual span info found)");
@@ -1711,7 +1711,7 @@ impl App {
                         ui.label("Individual Spans:");
                         ScrollArea::vertical().max_height(200.0).show(ui, |ui| {
                             for line in spans_info.lines() {
-                                ui.label(format!("- {}", line));
+                                ui.label(format!("- {line}"));
                             }
                         });
                     }
@@ -2014,7 +2014,7 @@ impl App {
                         from_pos,
                         to_pos,
                         base_arrow_stroke,
-                        format!("{:.2} ms", distance_ms),
+                        format!("{distance_ms:.2} ms"),
                         should_draw_highlighted,
                         &arrow_key,
                     );
@@ -2110,7 +2110,7 @@ impl App {
                 from_pos,
                 to_pos,
                 base_arrow_stroke,
-                format!("{:.2} ms", distance_ms),
+                format!("{distance_ms:.2} ms"),
                 should_draw_highlighted,
                 &arrow_key,
             );
@@ -2223,7 +2223,7 @@ impl App {
             &mut self.defined_relations,
             &mut self.relation_views,
         ) {
-            eprintln!("Failed to load persistent data: {}", err);
+            eprintln!("Failed to load persistent data: {err}");
         }
     }
 
@@ -2234,7 +2234,7 @@ impl App {
             &self.defined_relations,
             &self.relation_views,
         ) {
-            eprintln!("Failed to save persistent data: {}", err);
+            eprintln!("Failed to save persistent data: {err}");
         }
     }
 
@@ -2582,10 +2582,7 @@ fn get_time_dots(start_time: TimePoint, end_time: TimePoint) -> Vec<TimePoint> {
         delta /= 10.0;
         iterations += 1;
         if iterations > 10000 {
-            println!(
-                "WARN: get_time_dots looped!: start_time: {}, end_time: {}",
-                start_time, end_time
-            );
+            println!("WARN: get_time_dots looped!: start_time: {start_time}, end_time: {end_time}");
             return vec![];
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1649,13 +1649,13 @@ impl App {
         }
 
         if level == 0 {
-            // Top level spans get a color line at the top
+            // Grouped spans get a color line at the top
             ui.painter().line(
                 vec![
                     Pos2::new(start_x, start_height),
                     Pos2::new(end_x, start_height),
                 ],
-                Stroke::new(2.0, colors::INTENSE_RED),
+                Stroke::new(2.0, colors::INTENSE_GREEN),
             );
         }
 

--- a/src/modes.rs
+++ b/src/modes.rs
@@ -394,7 +394,7 @@ fn create_grouped_span(base_name: String, spans: Vec<Rc<Span>>) -> Span {
     let base_span = &spans[0];
     let mut grouped_span = (**base_span).clone();
 
-    grouped_span.name = format!("{} (group={})", base_name, span_count);
+    grouped_span.name = format!("{base_name} (group={span_count})");
     grouped_span.start_time = min_start;
     grouped_span.end_time = max_end;
     grouped_span.min_start_time.set(min_start);

--- a/src/modes.rs
+++ b/src/modes.rs
@@ -404,11 +404,6 @@ fn remove_spans_recursive(
             !span_locations.contains_key(&child.span_id)
                 || span_locations[&child.span_id] != Some(span.span_id.clone())
         });
-        let mut display_children = span.display_children.borrow_mut();
-        display_children.retain(|child| {
-            !span_locations.contains_key(&child.span_id)
-                || span_locations[&child.span_id] != Some(span.span_id.clone())
-        });
         true
     });
 }

--- a/src/modes.rs
+++ b/src/modes.rs
@@ -394,7 +394,7 @@ fn create_grouped_span(base_name: String, spans: Vec<Rc<Span>>) -> Span {
     let base_span = &spans[0];
     let mut grouped_span = (**base_span).clone();
 
-    grouped_span.name = format!("{base_name} (group={span_count})");
+    grouped_span.name = format!("{base_name} (total={span_count})");
     grouped_span.start_time = min_start;
     grouped_span.end_time = max_end;
     grouped_span.min_start_time.set(min_start);

--- a/src/modes.rs
+++ b/src/modes.rs
@@ -441,8 +441,10 @@ fn create_grouped_span(base_name: String, spans: Vec<Rc<Span>>) -> Span {
         }
     }
 
-    // Use the first span as the base
-    let base_span = &spans[0];
+    // Ensure the earliest span is used as the base
+    let mut spans_sorted_by_start = spans.clone();
+    spans_sorted_by_start.sort_by(|a, b| a.start_time.partial_cmp(&b.start_time).unwrap());
+    let base_span = &spans_sorted_by_start[0];
     let mut grouped_span = (**base_span).clone();
 
     grouped_span.name = format!("{base_name} (total={span_count})");
@@ -452,8 +454,9 @@ fn create_grouped_span(base_name: String, spans: Vec<Rc<Span>>) -> Span {
     grouped_span.max_end_time.set(max_end);
     grouped_span.active_segments = Some(active_segments);
 
-    // Store original spans information for hover tooltip
-    let spans_info = spans
+    // Store original spans information for hover tooltip,
+    // the spans are already sorted by start time
+    let spans_info = spans_sorted_by_start
         .iter()
         .map(|s| {
             format!(

--- a/src/modes.rs
+++ b/src/modes.rs
@@ -330,17 +330,14 @@ fn apply_grouping(spans: &mut Vec<Rc<Span>>) {
             .unwrap_or_else(|| span.name.clone());
 
         // TODO: make grouping attribute customizable
-        let height = span
-            .attributes
-            .get("height")
-            .and_then(|v| v.as_ref())
-            .and_then(|v| match v {
-                Value::IntValue(i) => Some(i.to_string()),
-                Value::DoubleValue(d) => Some(d.to_string()),
-                Value::StringValue(s) => Some(s.clone()),
-                _ => None,
-            })
-            .unwrap_or_else(|| "unknown".to_string());
+        let height_value_opt = span.attributes.get("height").cloned().unwrap_or(None);
+        let height = value_to_text(&height_value_opt);
+        if height == "empty" {
+            println!(
+                "WARN: grouping span '{}' on node '{}' without 'height' attribute",
+                original_name, span.node.name
+            );
+        }
 
         let grouping_key = (span.node.name.clone(), height, original_name);
         groups.entry(grouping_key).or_default().push(span);

--- a/src/persistent.rs
+++ b/src/persistent.rs
@@ -166,5 +166,5 @@ fn persistent_data_file_path() -> PathBuf {
 
 fn temporary_write_file_path() -> PathBuf {
     let random_number: u64 = rand::random();
-    persistent_data_folder().join(format!("temporary_persistent_data{}.json", random_number))
+    persistent_data_folder().join(format!("temporary_persistent_data{random_number}.json"))
 }

--- a/src/profiling.rs
+++ b/src/profiling.rs
@@ -84,7 +84,7 @@ impl Profiler {
                 } else {
                     0.0
                 };
-                println!("[PROFILE]  - Average FPS: {:.2}", fps);
+                println!("[PROFILE]  - Average FPS: {fps:.2}");
                 println!("[PROFILE] --- End of Report ---");
             }
         });

--- a/src/structured_modes.rs
+++ b/src/structured_modes.rs
@@ -603,10 +603,29 @@ fn critical_path_structured_mode() -> StructuredMode {
                 decision: SpanDecision {
                     visible: true,
                     display_length: DisplayLength::Text,
-                    replace_name: "VCE".to_string(),
+                    replace_name: String::new(),
                     add_height_to_name: true,
                     add_shard_id_to_name: true,
                     group: true,
+                },
+            },
+            SpanRule {
+                name: "generate_state_witness_parts".to_string(),
+                selector: SpanSelector {
+                    span_name_condition: MatchCondition {
+                        operator: MatchOperator::EqualTo,
+                        value: "generate_state_witness_parts".to_string(),
+                    },
+                    node_name_condition: MatchCondition::any(),
+                    attribute_conditions: vec![],
+                },
+                decision: SpanDecision {
+                    visible: true,
+                    display_length: DisplayLength::Text,
+                    replace_name: String::new(),
+                    add_height_to_name: true,
+                    add_shard_id_to_name: true,
+                    group: false,
                 },
             },
             SpanRule {

--- a/src/structured_modes.rs
+++ b/src/structured_modes.rs
@@ -52,6 +52,9 @@ pub struct SpanDecision {
     pub add_height_to_name: bool,
     /// Add shard id (e.g s=123) to the span's name, the shard id is read from the attributes.
     pub add_shard_id_to_name: bool,
+    /// Whether to group spans with the same name into a single aggregated span.
+    #[serde(default)]
+    pub group: bool,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -155,6 +158,7 @@ impl StructuredMode {
             replace_name: String::new(),
             add_height_to_name: false,
             add_shard_id_to_name: false,
+            group: false,
         }
     }
 }
@@ -209,6 +213,7 @@ pub fn everything_structured_mode() -> StructuredMode {
                     replace_name: "VCE".to_string(),
                     add_height_to_name: true,
                     add_shard_id_to_name: true,
+                    group: false,
                 },
             },
             // All spans should be visible, their length should be based on time.
@@ -225,6 +230,7 @@ pub fn everything_structured_mode() -> StructuredMode {
                     replace_name: String::new(),
                     add_height_to_name: true,
                     add_shard_id_to_name: true,
+                    group: false,
                 },
             },
         ],
@@ -254,6 +260,7 @@ pub fn block_production_structured_mode() -> StructuredMode {
                     replace_name: "VCSW".to_string(),
                     add_height_to_name: true,
                     add_shard_id_to_name: true,
+                    group: false,
                 },
             },
             // Show "validate_chunk_endorsement" as "VCE", helps with performance and visual clutter.
@@ -273,6 +280,7 @@ pub fn block_production_structured_mode() -> StructuredMode {
                     replace_name: "VCE".to_string(),
                     add_height_to_name: true,
                     add_shard_id_to_name: true,
+                    group: false,
                 },
             },
             // All spans with 'block_production' tag should be visible.
@@ -295,6 +303,7 @@ pub fn block_production_structured_mode() -> StructuredMode {
                     replace_name: String::new(),
                     add_height_to_name: true,
                     add_shard_id_to_name: true,
+                    group: false,
                 },
             },
         ],
@@ -322,6 +331,7 @@ fn block_production_without_vce_structured_mode() -> StructuredMode {
             replace_name: String::new(),
             add_height_to_name: false,
             add_shard_id_to_name: false,
+            group: false,
         },
     };
 
@@ -354,6 +364,7 @@ fn witness_distribution_structured_mode() -> StructuredMode {
                 replace_name: String::new(),
                 add_height_to_name: true,
                 add_shard_id_to_name: true,
+                group: false,
             },
         }],
         is_builtin: true,
@@ -391,15 +402,16 @@ fn witness_distribution_shard_0_structured_mode() -> StructuredMode {
                 replace_name: String::new(),
                 add_height_to_name: true,
                 add_shard_id_to_name: true,
+                group: false,
             },
         }],
         is_builtin: true,
     }
 }
 
-fn critical_path_shard_0_structured_mode() -> StructuredMode {
+fn critical_path_structured_mode() -> StructuredMode {
     StructuredMode {
-        name: "Critical Path (shard 0)".to_string(),
+        name: "Critical Path".to_string(),
         span_rules: vec![
             SpanRule {
                 name: "send_witness_to_client".to_string(),
@@ -409,13 +421,7 @@ fn critical_path_shard_0_structured_mode() -> StructuredMode {
                         value: "send_witness_to_client".to_string(),
                     },
                     node_name_condition: MatchCondition::any(),
-                    attribute_conditions: vec![(
-                        "shard_id".to_string(),
-                        MatchCondition {
-                            operator: MatchOperator::EqualTo,
-                            value: "0".to_string(),
-                        },
-                    )],
+                    attribute_conditions: vec![],
                 },
                 decision: SpanDecision {
                     visible: true,
@@ -423,6 +429,7 @@ fn critical_path_shard_0_structured_mode() -> StructuredMode {
                     replace_name: String::new(),
                     add_height_to_name: true,
                     add_shard_id_to_name: true,
+                    group: true,
                 },
             },
             SpanRule {
@@ -441,6 +448,26 @@ fn critical_path_shard_0_structured_mode() -> StructuredMode {
                     replace_name: String::new(),
                     add_height_to_name: true,
                     add_shard_id_to_name: true,
+                    group: false,
+                },
+            },
+            SpanRule {
+                name: "produce_chunk_internal".to_string(),
+                selector: SpanSelector {
+                    span_name_condition: MatchCondition {
+                        operator: MatchOperator::EqualTo,
+                        value: "produce_chunk_internal".to_string(),
+                    },
+                    node_name_condition: MatchCondition::any(),
+                    attribute_conditions: vec![],
+                },
+                decision: SpanDecision {
+                    visible: true,
+                    display_length: DisplayLength::Text,
+                    replace_name: "produce_chunk".to_string(),
+                    add_height_to_name: true,
+                    add_shard_id_to_name: true,
+                    group: false,
                 },
             },
             SpanRule {
@@ -459,6 +486,7 @@ fn critical_path_shard_0_structured_mode() -> StructuredMode {
                     replace_name: String::new(),
                     add_height_to_name: true,
                     add_shard_id_to_name: true,
+                    group: false,
                 },
             },
             SpanRule {
@@ -469,13 +497,7 @@ fn critical_path_shard_0_structured_mode() -> StructuredMode {
                         value: "validate_chunk_state_witness".to_string(),
                     },
                     node_name_condition: MatchCondition::any(),
-                    attribute_conditions: vec![(
-                        "shard_id".to_string(),
-                        MatchCondition {
-                            operator: MatchOperator::EqualTo,
-                            value: "0".to_string(),
-                        },
-                    )],
+                    attribute_conditions: vec![],
                 },
                 decision: SpanDecision {
                     visible: true,
@@ -483,6 +505,7 @@ fn critical_path_shard_0_structured_mode() -> StructuredMode {
                     replace_name: String::new(),
                     add_height_to_name: true,
                     add_shard_id_to_name: true,
+                    group: true,
                 },
             },
             SpanRule {
@@ -501,6 +524,7 @@ fn critical_path_shard_0_structured_mode() -> StructuredMode {
                     replace_name: String::new(),
                     add_height_to_name: true,
                     add_shard_id_to_name: true,
+                    group: false,
                 },
             },
             SpanRule {
@@ -511,7 +535,13 @@ fn critical_path_shard_0_structured_mode() -> StructuredMode {
                         value: "do_apply_chunks".to_string(),
                     },
                     node_name_condition: MatchCondition::any(),
-                    attribute_conditions: vec![],
+                    attribute_conditions: vec![(
+                        "block".to_string(),
+                        MatchCondition {
+                            operator: MatchOperator::Contains,
+                            value: "Optimistic".to_string(),
+                        },
+                    )],
                 },
                 decision: SpanDecision {
                     visible: true,
@@ -519,6 +549,7 @@ fn critical_path_shard_0_structured_mode() -> StructuredMode {
                     replace_name: String::new(),
                     add_height_to_name: true,
                     add_shard_id_to_name: true,
+                    group: false,
                 },
             },
             SpanRule {
@@ -537,6 +568,7 @@ fn critical_path_shard_0_structured_mode() -> StructuredMode {
                     replace_name: String::new(),
                     add_height_to_name: true,
                     add_shard_id_to_name: true,
+                    group: false,
                 },
             },
             SpanRule {
@@ -547,13 +579,7 @@ fn critical_path_shard_0_structured_mode() -> StructuredMode {
                         value: "decode_state_witness".to_string(),
                     },
                     node_name_condition: MatchCondition::any(),
-                    attribute_conditions: vec![(
-                        "shard_id".to_string(),
-                        MatchCondition {
-                            operator: MatchOperator::EqualTo,
-                            value: "0".to_string(),
-                        },
-                    )],
+                    attribute_conditions: vec![],
                 },
                 decision: SpanDecision {
                     visible: true,
@@ -561,6 +587,7 @@ fn critical_path_shard_0_structured_mode() -> StructuredMode {
                     replace_name: String::new(),
                     add_height_to_name: true,
                     add_shard_id_to_name: true,
+                    group: true,
                 },
             },
             SpanRule {
@@ -571,13 +598,7 @@ fn critical_path_shard_0_structured_mode() -> StructuredMode {
                         value: "validate_chunk_endorsement".to_string(),
                     },
                     node_name_condition: MatchCondition::any(),
-                    attribute_conditions: vec![(
-                        "shard_id".to_string(),
-                        MatchCondition {
-                            operator: MatchOperator::EqualTo,
-                            value: "0".to_string(),
-                        },
-                    )],
+                    attribute_conditions: vec![],
                 },
                 decision: SpanDecision {
                     visible: true,
@@ -585,6 +606,7 @@ fn critical_path_shard_0_structured_mode() -> StructuredMode {
                     replace_name: "VCE".to_string(),
                     add_height_to_name: true,
                     add_shard_id_to_name: true,
+                    group: true,
                 },
             },
             SpanRule {
@@ -603,6 +625,7 @@ fn critical_path_shard_0_structured_mode() -> StructuredMode {
                     replace_name: String::new(),
                     add_height_to_name: true,
                     add_shard_id_to_name: true,
+                    group: false,
                 },
             },
             SpanRule {
@@ -621,6 +644,7 @@ fn critical_path_shard_0_structured_mode() -> StructuredMode {
                     replace_name: String::new(),
                     add_height_to_name: true,
                     add_shard_id_to_name: true,
+                    group: false,
                 },
             },
             SpanRule {
@@ -639,6 +663,7 @@ fn critical_path_shard_0_structured_mode() -> StructuredMode {
                     replace_name: String::new(),
                     add_height_to_name: true,
                     add_shard_id_to_name: true,
+                    group: false,
                 },
             },
             SpanRule {
@@ -649,13 +674,7 @@ fn critical_path_shard_0_structured_mode() -> StructuredMode {
                         value: "decode_witness_parts".to_string(),
                     },
                     node_name_condition: MatchCondition::any(),
-                    attribute_conditions: vec![(
-                        "shard_id".to_string(),
-                        MatchCondition {
-                            operator: MatchOperator::EqualTo,
-                            value: "0".to_string(),
-                        },
-                    )],
+                    attribute_conditions: vec![],
                 },
                 decision: SpanDecision {
                     visible: true,
@@ -663,6 +682,7 @@ fn critical_path_shard_0_structured_mode() -> StructuredMode {
                     replace_name: String::new(),
                     add_height_to_name: true,
                     add_shard_id_to_name: true,
+                    group: true,
                 },
             },
         ],
@@ -687,6 +707,7 @@ fn show_span(name: &str) -> SpanRule {
             replace_name: String::new(),
             add_height_to_name: true,
             add_shard_id_to_name: true,
+            group: false,
         },
     }
 }
@@ -700,6 +721,6 @@ pub fn builtin_structured_modes() -> Vec<StructuredMode> {
         block_production_without_vce_structured_mode(),
         witness_distribution_structured_mode(),
         witness_distribution_shard_0_structured_mode(),
-        critical_path_shard_0_structured_mode(),
+        critical_path_structured_mode(),
     ]
 }

--- a/src/structured_modes.rs
+++ b/src/structured_modes.rs
@@ -692,7 +692,7 @@ fn critical_path_structured_mode() -> StructuredMode {
 
 fn show_span(name: &str) -> SpanRule {
     SpanRule {
-        name: format!("Show {}", name),
+        name: format!("Show {name}"),
         selector: SpanSelector {
             span_name_condition: MatchCondition {
                 operator: MatchOperator::EqualTo,

--- a/src/structured_modes.rs
+++ b/src/structured_modes.rs
@@ -397,6 +397,279 @@ fn witness_distribution_shard_0_structured_mode() -> StructuredMode {
     }
 }
 
+fn critical_path_shard_0_structured_mode() -> StructuredMode {
+    StructuredMode {
+        name: "Critical Path (shard 0)".to_string(),
+        span_rules: vec![
+            SpanRule {
+                name: "send_witness_to_client".to_string(),
+                selector: SpanSelector {
+                    span_name_condition: MatchCondition {
+                        operator: MatchOperator::EqualTo,
+                        value: "send_witness_to_client".to_string(),
+                    },
+                    node_name_condition: MatchCondition::any(),
+                    attribute_conditions: vec![(
+                        "shard_id".to_string(),
+                        MatchCondition {
+                            operator: MatchOperator::EqualTo,
+                            value: "0".to_string(),
+                        },
+                    )],
+                },
+                decision: SpanDecision {
+                    visible: true,
+                    display_length: DisplayLength::Text,
+                    replace_name: String::new(),
+                    add_height_to_name: true,
+                    add_shard_id_to_name: true,
+                },
+            },
+            SpanRule {
+                name: "produce_chunk".to_string(),
+                selector: SpanSelector {
+                    span_name_condition: MatchCondition {
+                        operator: MatchOperator::EqualTo,
+                        value: "produce_chunk".to_string(),
+                    },
+                    node_name_condition: MatchCondition::any(),
+                    attribute_conditions: vec![],
+                },
+                decision: SpanDecision {
+                    visible: true,
+                    display_length: DisplayLength::Text,
+                    replace_name: String::new(),
+                    add_height_to_name: true,
+                    add_shard_id_to_name: true,
+                },
+            },
+            SpanRule {
+                name: "produce_block_on_head".to_string(),
+                selector: SpanSelector {
+                    span_name_condition: MatchCondition {
+                        operator: MatchOperator::EqualTo,
+                        value: "produce_block_on_head".to_string(),
+                    },
+                    node_name_condition: MatchCondition::any(),
+                    attribute_conditions: vec![],
+                },
+                decision: SpanDecision {
+                    visible: true,
+                    display_length: DisplayLength::Text,
+                    replace_name: String::new(),
+                    add_height_to_name: true,
+                    add_shard_id_to_name: true,
+                },
+            },
+            SpanRule {
+                name: "validate_chunk_state_witness".to_string(),
+                selector: SpanSelector {
+                    span_name_condition: MatchCondition {
+                        operator: MatchOperator::EqualTo,
+                        value: "validate_chunk_state_witness".to_string(),
+                    },
+                    node_name_condition: MatchCondition::any(),
+                    attribute_conditions: vec![(
+                        "shard_id".to_string(),
+                        MatchCondition {
+                            operator: MatchOperator::EqualTo,
+                            value: "0".to_string(),
+                        },
+                    )],
+                },
+                decision: SpanDecision {
+                    visible: true,
+                    display_length: DisplayLength::Text,
+                    replace_name: String::new(),
+                    add_height_to_name: true,
+                    add_shard_id_to_name: true,
+                },
+            },
+            SpanRule {
+                name: "start_process_block_async".to_string(),
+                selector: SpanSelector {
+                    span_name_condition: MatchCondition {
+                        operator: MatchOperator::EqualTo,
+                        value: "start_process_block_async".to_string(),
+                    },
+                    node_name_condition: MatchCondition::any(),
+                    attribute_conditions: vec![],
+                },
+                decision: SpanDecision {
+                    visible: true,
+                    display_length: DisplayLength::Text,
+                    replace_name: String::new(),
+                    add_height_to_name: true,
+                    add_shard_id_to_name: true,
+                },
+            },
+            SpanRule {
+                name: "do_apply_chunks".to_string(),
+                selector: SpanSelector {
+                    span_name_condition: MatchCondition {
+                        operator: MatchOperator::EqualTo,
+                        value: "do_apply_chunks".to_string(),
+                    },
+                    node_name_condition: MatchCondition::any(),
+                    attribute_conditions: vec![],
+                },
+                decision: SpanDecision {
+                    visible: true,
+                    display_length: DisplayLength::Text,
+                    replace_name: String::new(),
+                    add_height_to_name: true,
+                    add_shard_id_to_name: true,
+                },
+            },
+            SpanRule {
+                name: "send_chunk_state_witness".to_string(),
+                selector: SpanSelector {
+                    span_name_condition: MatchCondition {
+                        operator: MatchOperator::EqualTo,
+                        value: "send_chunk_state_witness".to_string(),
+                    },
+                    node_name_condition: MatchCondition::any(),
+                    attribute_conditions: vec![],
+                },
+                decision: SpanDecision {
+                    visible: true,
+                    display_length: DisplayLength::Text,
+                    replace_name: String::new(),
+                    add_height_to_name: true,
+                    add_shard_id_to_name: true,
+                },
+            },
+            SpanRule {
+                name: "decode_state_witness".to_string(),
+                selector: SpanSelector {
+                    span_name_condition: MatchCondition {
+                        operator: MatchOperator::EqualTo,
+                        value: "decode_state_witness".to_string(),
+                    },
+                    node_name_condition: MatchCondition::any(),
+                    attribute_conditions: vec![(
+                        "shard_id".to_string(),
+                        MatchCondition {
+                            operator: MatchOperator::EqualTo,
+                            value: "0".to_string(),
+                        },
+                    )],
+                },
+                decision: SpanDecision {
+                    visible: true,
+                    display_length: DisplayLength::Text,
+                    replace_name: String::new(),
+                    add_height_to_name: true,
+                    add_shard_id_to_name: true,
+                },
+            },
+            SpanRule {
+                name: "validate_chunk_endorsement".to_string(),
+                selector: SpanSelector {
+                    span_name_condition: MatchCondition {
+                        operator: MatchOperator::EqualTo,
+                        value: "validate_chunk_endorsement".to_string(),
+                    },
+                    node_name_condition: MatchCondition::any(),
+                    attribute_conditions: vec![(
+                        "shard_id".to_string(),
+                        MatchCondition {
+                            operator: MatchOperator::EqualTo,
+                            value: "0".to_string(),
+                        },
+                    )],
+                },
+                decision: SpanDecision {
+                    visible: true,
+                    display_length: DisplayLength::Text,
+                    replace_name: "VCE".to_string(),
+                    add_height_to_name: true,
+                    add_shard_id_to_name: true,
+                },
+            },
+            SpanRule {
+                name: "postprocess_ready_block".to_string(),
+                selector: SpanSelector {
+                    span_name_condition: MatchCondition {
+                        operator: MatchOperator::EqualTo,
+                        value: "postprocess_ready_block".to_string(),
+                    },
+                    node_name_condition: MatchCondition::any(),
+                    attribute_conditions: vec![],
+                },
+                decision: SpanDecision {
+                    visible: true,
+                    display_length: DisplayLength::Text,
+                    replace_name: String::new(),
+                    add_height_to_name: true,
+                    add_shard_id_to_name: true,
+                },
+            },
+            SpanRule {
+                name: "distribute_chunk_state_witness".to_string(),
+                selector: SpanSelector {
+                    span_name_condition: MatchCondition {
+                        operator: MatchOperator::EqualTo,
+                        value: "distribute_chunk_state_witness".to_string(),
+                    },
+                    node_name_condition: MatchCondition::any(),
+                    attribute_conditions: vec![],
+                },
+                decision: SpanDecision {
+                    visible: true,
+                    display_length: DisplayLength::Text,
+                    replace_name: String::new(),
+                    add_height_to_name: true,
+                    add_shard_id_to_name: true,
+                },
+            },
+            SpanRule {
+                name: "send partial_encoded_state_witnesses".to_string(),
+                selector: SpanSelector {
+                    span_name_condition: MatchCondition {
+                        operator: MatchOperator::EqualTo,
+                        value: "send partial_encoded_state_witnesses".to_string(),
+                    },
+                    node_name_condition: MatchCondition::any(),
+                    attribute_conditions: vec![],
+                },
+                decision: SpanDecision {
+                    visible: true,
+                    display_length: DisplayLength::Text,
+                    replace_name: String::new(),
+                    add_height_to_name: true,
+                    add_shard_id_to_name: true,
+                },
+            },
+            SpanRule {
+                name: "decode_witness_parts".to_string(),
+                selector: SpanSelector {
+                    span_name_condition: MatchCondition {
+                        operator: MatchOperator::EqualTo,
+                        value: "decode_witness_parts".to_string(),
+                    },
+                    node_name_condition: MatchCondition::any(),
+                    attribute_conditions: vec![(
+                        "shard_id".to_string(),
+                        MatchCondition {
+                            operator: MatchOperator::EqualTo,
+                            value: "0".to_string(),
+                        },
+                    )],
+                },
+                decision: SpanDecision {
+                    visible: true,
+                    display_length: DisplayLength::Text,
+                    replace_name: String::new(),
+                    add_height_to_name: true,
+                    add_shard_id_to_name: true,
+                },
+            },
+        ],
+        is_builtin: true,
+    }
+}
+
 fn show_span(name: &str) -> SpanRule {
     SpanRule {
         name: format!("Show {}", name),
@@ -427,5 +700,6 @@ pub fn builtin_structured_modes() -> Vec<StructuredMode> {
         block_production_without_vce_structured_mode(),
         witness_distribution_structured_mode(),
         witness_distribution_shard_0_structured_mode(),
+        critical_path_shard_0_structured_mode(),
     ]
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -56,6 +56,13 @@ pub struct Span {
 
     pub incoming_relations: RefCell<Vec<RelationInstance>>,
     pub outgoing_relations: RefCell<Vec<RelationInstance>>,
+
+    /// Active time segments for grouped spans. Each tuple represents (start_time, end_time)
+    /// of an active period within the overall span range.
+    /// - `None`: Regular span (no grouping)
+    /// - `Some(vec![])`: Span marked for grouping
+    /// - `Some(vec![...])`: Grouped span with actual active segments
+    pub active_segments: Option<Vec<(TimePoint, TimePoint)>>,
 }
 
 impl Span {

--- a/src/types.rs
+++ b/src/types.rs
@@ -150,7 +150,7 @@ pub fn value_to_text(value_opt: &Option<Value>) -> String {
                 .collect::<Vec<_>>()
                 .join(", ")
         ),
-        Value::BytesValue(b) => format!("{:?}", b), // TODO - hex? base64? maximum length?
+        Value::BytesValue(b) => format!("{b:?}"), // TODO - hex? base64? maximum length?
     }
 }
 
@@ -227,7 +227,7 @@ pub enum NodeIdentifier {
 impl fmt::Display for NodeIdentifier {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            NodeIdentifier::Node(name) => write!(f, "{}", name),
+            NodeIdentifier::Node(name) => write!(f, "{name}"),
             NodeIdentifier::AllNodes => write!(f, "ALL NODES"),
         }
     }

--- a/tests/analyze_dependency_test.rs
+++ b/tests/analyze_dependency_test.rs
@@ -1235,7 +1235,7 @@ fn test_complex_all_features_combined() {
 
     if modal.analysis_result.is_none() {
         if let Some(error) = modal.get_error_message() {
-            panic!("Analysis failed with error: {}", error);
+            panic!("Analysis failed with error: {error}");
         } else {
             panic!("Analysis failed with no error message");
         }
@@ -1249,7 +1249,7 @@ fn test_complex_all_features_combined() {
     if result.per_node_results.is_empty() {
         // Check if there's an error or if the combination of features prevents link formation
         if let Some(error) = modal.get_error_message() {
-            panic!("Analysis failed with error: {}", error);
+            panic!("Analysis failed with error: {error}");
         } else {
             panic!("No links formed - complex feature combination may have implementation issues");
         }
@@ -1726,8 +1726,7 @@ fn test_error_missing_target_spans() {
     let error = modal.get_error_message().unwrap();
     assert!(
         error.contains("No spans found with name 'nonexistent_target'"),
-        "Error message should mention the missing target span name, got: {}",
-        error
+        "Error message should mention the missing target span name, got: {error}"
     );
 }
 
@@ -2565,7 +2564,7 @@ fn test_parse_analysis_description() {
     let description = "Analysis of dependency: 'send_chunk_state_witness' -> 'validate_chunk_state_witness' (cardinality: 1-to-N, threshold: 4, linking by: height,shard_id, group by: none, scope: all nodes, timing: Earliest First, group aggregation: First Completed Group)";
 
     let result = modal.parse_and_fill_from_description(description);
-    assert!(result.is_ok(), "Parsing should succeed: {:?}", result);
+    assert!(result.is_ok(), "Parsing should succeed: {result:?}");
 
     // Verify all fields were set correctly
     assert_eq!(
@@ -2608,7 +2607,7 @@ fn test_parse_analysis_description_with_grouping() {
     let description = "Analysis of dependency: 'worker' -> 'processor' (cardinality: N-to-1, threshold: 2, linking by: none, group by: batch_id, scope: self, timing: Latest First, group aggregation: Wait For Last Group)";
 
     let result = modal.parse_and_fill_from_description(description);
-    assert!(result.is_ok(), "Parsing should succeed: {:?}", result);
+    assert!(result.is_ok(), "Parsing should succeed: {result:?}");
 
     // Verify fields
     assert_eq!(modal.get_source_span_name(), Some(&"worker".to_string()));

--- a/tests/test_helpers.rs
+++ b/tests/test_helpers.rs
@@ -51,6 +51,7 @@ pub fn create_test_span(
         time_display_length: Cell::new(0.0),
         incoming_relations: RefCell::new(vec![]),
         outgoing_relations: RefCell::new(vec![]),
+        active_segments: None,
     })
 }
 
@@ -90,6 +91,7 @@ pub fn create_test_span_with_attributes(
         time_display_length: Cell::new(0.0),
         incoming_relations: RefCell::new(vec![]),
         outgoing_relations: RefCell::new(vec![]),
+        active_segments: None,
     })
 }
 


### PR DESCRIPTION
This PR adds a new built in structured mode to visualize the critical path of the chain.

I initially added all the spans that are on the critical path, but it was hard to visualize a complete picture because validations and endorsements are just too many.

To solve this issue I'm adding a new option to group similar spans based on their name, height, and node.

This is the result:

---

<img width="1914" height="378" alt="Screenshot 2025-08-06 at 17 17 28" src="https://github.com/user-attachments/assets/09a2be34-230c-4ecd-8057-cba6ae024ce2" />

---

<img width="580" height="227" alt="image" src="https://github.com/user-attachments/assets/0b38838f-91d4-4af8-b926-522eb7b0f9ba" />

---

"Grouping" can be used freely in any other user defined mode.