### PR TITLE
Make produce_chunk relations more generic

### DIFF
--- a/src/builtin_relations.rs
+++ b/src/builtin_relations.rs
@@ -183,7 +183,7 @@ pub fn postprocess_ready_block_to_produce_chunk_relation() -> Relation {
         name: "postprocess_ready_block -> produce_chunk".to_string(),
         description: "".to_string(),
         from_span_selector: SpanSelector::new_equal_name("postprocess_ready_block"),
-        to_span_selector: SpanSelector::new_equal_name("produce_chunk"),
+        to_span_selector: SpanSelector::new_name_contains("produce_chunk"),
         attribute_relations: vec![AttributeRelation {
             from_attribute: "height".to_string(),
             to_attribute: "height".to_string(),
@@ -202,7 +202,7 @@ pub fn produce_chunk_to_send_chunk_state_witness_relation() -> Relation {
         id: make_uuid_from_seed("produce_chunk -> send_chunk_state_witness"),
         name: "produce_chunk -> send_chunk_state_witness".to_string(),
         description: "".to_string(),
-        from_span_selector: SpanSelector::new_equal_name("produce_chunk"),
+        from_span_selector: SpanSelector::new_name_contains("produce_chunk"),
         to_span_selector: SpanSelector::new_equal_name("send_chunk_state_witness"),
         attribute_relations: vec![
             AttributeRelation {

--- a/src/structured_modes.rs
+++ b/src/structured_modes.rs
@@ -113,6 +113,17 @@ impl SpanSelector {
             attribute_conditions: vec![],
         }
     }
+
+    pub fn new_name_contains(name: &str) -> SpanSelector {
+        SpanSelector {
+            span_name_condition: MatchCondition {
+                operator: MatchOperator::Contains,
+                value: name.to_string(),
+            },
+            node_name_condition: MatchCondition::any(),
+            attribute_conditions: vec![],
+        }
+    }
 }
 
 impl MatchCondition {


### PR DESCRIPTION
Recently span name changed from `produce_chunk` to `produce_chunk_on_head`, which broke some relations. Let's make the relations more generic by changing the condition from "equals produce_chunk" to "contains produce_chunk". This will catch both span names.